### PR TITLE
feat: add referral system with per-signup bonus points

### DIFF
--- a/apps/dashboard/app/api/referrals/[action]/route.ts
+++ b/apps/dashboard/app/api/referrals/[action]/route.ts
@@ -1,0 +1,293 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq, count } from "drizzle-orm";
+import { createClient } from "@supabase/supabase-js";
+import { db } from "@/lib/server/db";
+import * as schema from "@/lib/server/schema";
+import { getAdminConfig } from "@/lib/server/config";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ action: string }> };
+
+function getSupabaseClient() {
+  const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Supabase environment variables not configured");
+  }
+  return createClient(supabaseUrl, serviceRoleKey);
+}
+
+function getCurrentWeek() {
+  const now = new Date();
+  const dayOfWeek = now.getDay();
+  const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+
+  const weekStart = new Date(now);
+  weekStart.setDate(now.getDate() + diffToMonday);
+  weekStart.setHours(0, 0, 0, 0);
+
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekStart.getDate() + 7);
+
+  return { weekStart, weekEnd };
+}
+
+function generateReferralCode(): string {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // Omit I, O, 0, 1 (look-alike)
+  let code = "";
+  for (let i = 0; i < 6; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+}
+
+async function ensureReferralCode(userId: string): Promise<string> {
+  // Return existing code if already set
+  const [user] = await db
+    .select({ referralCode: schema.users.referralCode })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+
+  if (user?.referralCode) {
+    return user.referralCode;
+  }
+
+  // Generate a unique code
+  let code = "";
+  let attempts = 0;
+  while (attempts < 10) {
+    code = generateReferralCode();
+    const existing = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.referralCode, code))
+      .limit(1);
+    if (existing.length === 0) break;
+    attempts++;
+  }
+
+  await db
+    .update(schema.users)
+    .set({ referralCode: code, updatedAt: new Date() })
+    .where(eq(schema.users.id, userId));
+
+  return code;
+}
+
+async function handleGetCode(req: NextRequest) {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = authHeader.replace("Bearer ", "");
+  const supabase = getSupabaseClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser(token);
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+
+  const { config } = await getAdminConfig();
+  const referralCode = await ensureReferralCode(user.id);
+
+  // Count how many users this person has referred
+  const [{ referralCount }] = await db
+    .select({ referralCount: count() })
+    .from(schema.users)
+    .where(eq(schema.users.referredBy, user.id));
+
+  // Check if this user has already applied someone else's referral code
+  const [currentUser] = await db
+    .select({ referredBy: schema.users.referredBy })
+    .from(schema.users)
+    .where(eq(schema.users.id, user.id))
+    .limit(1);
+
+  return NextResponse.json({
+    referralCode,
+    referralCount: Number(referralCount),
+    bonusPointsPerReferral: config.referralBonusPoints,
+    hasAppliedReferralCode: currentUser?.referredBy != null,
+  });
+}
+
+async function handleApplyCode(req: NextRequest) {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = authHeader.replace("Bearer ", "");
+  const supabase = getSupabaseClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser(token);
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { referralCode } = body as { referralCode?: string };
+
+  if (!referralCode || typeof referralCode !== "string") {
+    return NextResponse.json(
+      { error: "referralCode is required" },
+      { status: 400 }
+    );
+  }
+
+  const normalizedCode = referralCode.trim().toUpperCase();
+
+  // Look up the referrer by code
+  const [referrer] = await db
+    .select({ id: schema.users.id, referralCode: schema.users.referralCode })
+    .from(schema.users)
+    .where(eq(schema.users.referralCode, normalizedCode))
+    .limit(1);
+
+  if (!referrer) {
+    return NextResponse.json(
+      { error: "Invalid referral code" },
+      { status: 404 }
+    );
+  }
+
+  // Prevent self-referral
+  if (referrer.id === user.id) {
+    return NextResponse.json(
+      { error: "You cannot use your own referral code" },
+      { status: 400 }
+    );
+  }
+
+  // Check if this user has already applied a referral code
+  const [currentUser] = await db
+    .select({
+      referredBy: schema.users.referredBy,
+      referralBonusApplied: schema.users.referralBonusApplied,
+    })
+    .from(schema.users)
+    .where(eq(schema.users.id, user.id))
+    .limit(1);
+
+  if (!currentUser) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  if (currentUser.referredBy != null) {
+    return NextResponse.json(
+      { error: "You have already applied a referral code" },
+      { status: 400 }
+    );
+  }
+
+  const { config } = await getAdminConfig();
+  const bonusPoints = config.referralBonusPoints;
+
+  // Mark the applying user as referred, and set bonus-applied flag
+  await db
+    .update(schema.users)
+    .set({
+      referredBy: referrer.id,
+      referralBonusApplied: true,
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.users.id, user.id));
+
+  // Credit the referrer's current-week allowance
+  const { weekStart, weekEnd } = getCurrentWeek();
+
+  let weeklyPool = await db
+    .select()
+    .from(schema.weeklyPools)
+    .where(eq(schema.weeklyPools.weekStart, weekStart))
+    .limit(1);
+
+  if (weeklyPool.length === 0) {
+    const [newPool] = await db
+      .insert(schema.weeklyPools)
+      .values({
+        weekStart,
+        weekEnd,
+        totalAmount: "0",
+        allocatedAmount: "0",
+        remainingAmount: "0",
+      })
+      .returning();
+    weeklyPool = [newPool];
+  }
+
+  const poolId = weeklyPool[0].id;
+
+  const referrerAllowance = await db
+    .select()
+    .from(schema.userAllowances)
+    .where(
+      and(
+        eq(schema.userAllowances.userId, referrer.id),
+        eq(schema.userAllowances.weeklyPoolId, poolId)
+      )
+    )
+    .limit(1);
+
+  if (referrerAllowance.length > 0) {
+    // Allowance exists — add bonus to both weeklyLimit and remainingAmount
+    const existing = referrerAllowance[0];
+    const newLimit = parseFloat(existing.weeklyLimit) + bonusPoints;
+    const newRemaining = parseFloat(existing.remainingAmount) + bonusPoints;
+    await db
+      .update(schema.userAllowances)
+      .set({
+        weeklyLimit: newLimit.toString(),
+        remainingAmount: newRemaining.toString(),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.userAllowances.id, existing.id));
+  } else {
+    // Referrer has no allowance row yet for this week — create one with the bonus on top
+    const defaultWeeklyLimit = config.defaultWeeklyAllowance + bonusPoints;
+    await db.insert(schema.userAllowances).values({
+      userId: referrer.id,
+      weeklyPoolId: poolId,
+      weeklyLimit: defaultWeeklyLimit.toString(),
+      usedAmount: "0",
+      remainingAmount: defaultWeeklyLimit.toString(),
+    });
+  }
+
+  return NextResponse.json({
+    success: true,
+    bonusPointsAwarded: bonusPoints,
+    message: `Referral applied! Your referrer earned ${bonusPoints} bonus points.`,
+  });
+}
+
+async function dispatch(req: NextRequest, ctx: Ctx) {
+  const { action } = await ctx.params;
+
+  if (req.method === "GET" && action === "code") {
+    return handleGetCode(req);
+  }
+
+  if (req.method === "POST" && action === "apply") {
+    return handleApplyCode(req);
+  }
+
+  return NextResponse.json({ error: "Not found" }, { status: 404 });
+}
+
+export async function GET(req: NextRequest, ctx: Ctx) {
+  return dispatch(req, ctx);
+}
+
+export async function POST(req: NextRequest, ctx: Ctx) {
+  return dispatch(req, ctx);
+}

--- a/apps/dashboard/app/api/referrals/[action]/route.ts
+++ b/apps/dashboard/app/api/referrals/[action]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, eq, count } from "drizzle-orm";
+import { and, eq, count, gt, lt, desc } from "drizzle-orm";
 import { createClient } from "@supabase/supabase-js";
 import { db } from "@/lib/server/db";
 import * as schema from "@/lib/server/schema";
@@ -270,6 +270,62 @@ async function handleApplyCode(req: NextRequest) {
   });
 }
 
+async function handleMatch(req: NextRequest) {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = authHeader.replace("Bearer ", "");
+  const supabase = getSupabaseClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser(token);
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+
+  // Don't bother matching if they've already applied a code
+  const [currentUser] = await db
+    .select({ referredBy: schema.users.referredBy })
+    .from(schema.users)
+    .where(eq(schema.users.id, user.id))
+    .limit(1);
+
+  if (currentUser?.referredBy != null) {
+    return NextResponse.json({ referralCode: null });
+  }
+
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
+
+  const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000);
+
+  const [match] = await db
+    .select({ referralCode: schema.referralFingerprints.referralCode })
+    .from(schema.referralFingerprints)
+    .where(
+      and(
+        eq(schema.referralFingerprints.ipAddress, ip),
+        gt(schema.referralFingerprints.createdAt, fifteenMinutesAgo)
+      )
+    )
+    .orderBy(desc(schema.referralFingerprints.createdAt))
+    .limit(1);
+
+  // Lazy cleanup of old fingerprints
+  const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  await db
+    .delete(schema.referralFingerprints)
+    .where(lt(schema.referralFingerprints.createdAt, oneDayAgo));
+
+  return NextResponse.json({ referralCode: match?.referralCode ?? null });
+}
+
 async function dispatch(req: NextRequest, ctx: Ctx) {
   const { action } = await ctx.params;
 
@@ -279,6 +335,10 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
 
   if (req.method === "POST" && action === "apply") {
     return handleApplyCode(req);
+  }
+
+  if (req.method === "POST" && action === "match") {
+    return handleMatch(req);
   }
 
   return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/apps/dashboard/app/r/[code]/page.tsx
+++ b/apps/dashboard/app/r/[code]/page.tsx
@@ -1,0 +1,247 @@
+import { headers } from "next/headers";
+import { db } from "@/lib/server/db";
+import * as schema from "@/lib/server/schema";
+import { eq, lt } from "drizzle-orm";
+import { getAdminConfig } from "@/lib/server/config";
+
+type Props = { params: Promise<{ code: string }> };
+
+export default async function ReferralRedirectPage({ params }: Props) {
+  const { code } = await params;
+  const headersList = await headers();
+
+  const ip =
+    headersList.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    headersList.get("x-real-ip") ??
+    "unknown";
+
+  const normalizedCode = code.toUpperCase();
+
+  const [referrer] = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(eq(schema.users.referralCode, normalizedCode))
+    .limit(1);
+
+  const valid = !!referrer;
+
+  if (valid) {
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    await Promise.all([
+      db.insert(schema.referralFingerprints).values({
+        referralCode: normalizedCode,
+        ipAddress: ip,
+      }),
+      db
+        .delete(schema.referralFingerprints)
+        .where(lt(schema.referralFingerprints.createdAt, oneDayAgo)),
+    ]);
+  }
+
+  const { config } = await getAdminConfig();
+  const storeUrl = config.iosStoreUrl;
+
+  return (
+    <>
+      {/* React 19 hoists <style> tags to <head> automatically */}
+      <style>{`
+        .referral-page {
+          min-height: 100dvh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 24px;
+          position: relative;
+          overflow: hidden;
+        }
+        .referral-page::before {
+          content: '';
+          position: fixed;
+          inset: 0;
+          background:
+            radial-gradient(ellipse 80% 60% at 50% -10%, rgba(201,148,62,0.12) 0%, transparent 60%),
+            radial-gradient(ellipse 50% 40% at 100% 100%, rgba(201,148,62,0.05) 0%, transparent 50%);
+          pointer-events: none;
+          z-index: 0;
+        }
+        .referral-card {
+          position: relative;
+          z-index: 1;
+          max-width: 400px;
+          width: 100%;
+          text-align: center;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+        }
+        .r-wordmark {
+          font-family: var(--font-display), 'Instrument Serif', Georgia, serif;
+          font-size: 2.4rem;
+          font-weight: 400;
+          color: #f0e8db;
+          letter-spacing: -0.02em;
+          line-height: 1;
+          margin: 0 0 8px;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.05s both;
+        }
+        .r-wordmark em {
+          color: #c9943e;
+          font-style: italic;
+        }
+        .r-tagline {
+          font-size: 0.72rem;
+          color: #5c564e;
+          text-transform: uppercase;
+          letter-spacing: 0.16em;
+          font-weight: 500;
+          margin: 0 0 48px;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both;
+        }
+        .r-divider {
+          width: 40px;
+          height: 1px;
+          background: #2a2621;
+          margin: 0 auto 36px;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.15s both;
+        }
+        .r-invite-label {
+          font-size: 0.63rem;
+          color: #5c564e;
+          text-transform: uppercase;
+          letter-spacing: 0.16em;
+          font-weight: 600;
+          margin: 0 0 12px;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.18s both;
+        }
+        .r-headline {
+          font-family: var(--font-display), 'Instrument Serif', Georgia, serif;
+          font-size: 2rem;
+          font-weight: 400;
+          color: #f0e8db;
+          line-height: 1.25;
+          margin: 0 0 12px;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.22s both;
+        }
+        .r-headline.muted { color: #8a8278; }
+        .r-subhead {
+          font-size: 0.88rem;
+          color: #8a8278;
+          line-height: 1.65;
+          margin: 0 0 36px;
+          font-weight: 300;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.26s both;
+        }
+        .r-code-block {
+          display: inline-block;
+          background: #1a1714;
+          border: 1px solid #2a2621;
+          border-radius: 12px;
+          padding: 14px 28px;
+          margin: 0 0 36px;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.3s both;
+        }
+        .r-code-label {
+          font-size: 0.6rem;
+          color: #5c564e;
+          text-transform: uppercase;
+          letter-spacing: 0.16em;
+          font-weight: 600;
+          margin: 0 0 6px;
+        }
+        .r-code-value {
+          font-family: var(--font-mono), 'JetBrains Mono', monospace;
+          font-size: 1.8rem;
+          font-weight: 500;
+          color: #c9943e;
+          letter-spacing: 0.12em;
+          margin: 0;
+        }
+        .r-cta {
+          display: inline-flex;
+          align-items: center;
+          gap: 10px;
+          background: #c9943e;
+          color: #0d0b09;
+          font-family: var(--font-body), 'Outfit', system-ui, sans-serif;
+          font-size: 0.9rem;
+          font-weight: 600;
+          padding: 14px 28px;
+          border-radius: 100px;
+          text-decoration: none;
+          transition: background 0.2s, transform 0.15s;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.34s both;
+          margin-bottom: 16px;
+        }
+        .r-cta:hover { background: #e6b455; transform: translateY(-1px); }
+        .r-note {
+          font-size: 0.7rem;
+          color: #3d3730;
+          font-family: var(--font-mono), monospace;
+          font-weight: 300;
+          margin: 0;
+          animation: r-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.4s both;
+        }
+        @keyframes r-rise {
+          from { opacity: 0; transform: translateY(16px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+
+      {valid && storeUrl && (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `setTimeout(function(){window.location.href=${JSON.stringify(storeUrl)};},1000);`,
+          }}
+        />
+      )}
+
+      <div className="referral-page">
+        <div className="referral-card">
+          <p className="r-wordmark">
+            Slug<em>Swap</em>
+          </p>
+          <p className="r-tagline">Share dining points</p>
+          <div className="r-divider" />
+
+          {valid ? (
+            <>
+              <p className="r-invite-label">You&rsquo;ve been invited</p>
+              <h1 className="r-headline">
+                Free dining points<br />
+                <em>are waiting for you.</em>
+              </h1>
+              <p className="r-subhead">
+                Download SlugSwap and enter your referral code to earn bonus
+                points when you sign up.
+              </p>
+              <div className="r-code-block">
+                <p className="r-code-label">Your referral code</p>
+                <p className="r-code-value">{normalizedCode}</p>
+              </div>
+              <br />
+              {storeUrl ? (
+                <>
+                  <a href={storeUrl} className="r-cta">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+                    </svg>
+                    Download on the App Store
+                  </a>
+                  <p className="r-note">Redirecting automatically&hellip;</p>
+                </>
+              ) : (
+                <p className="r-note">Search &ldquo;SlugSwap&rdquo; on the App Store</p>
+              )}
+            </>
+          ) : (
+            <>
+              <h1 className="r-headline muted">Link not found</h1>
+              <p className="r-subhead">
+                This referral link is invalid or has expired.<br />
+                Ask your friend to share a fresh link.
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/dashboard/lib/server/config.ts
+++ b/apps/dashboard/lib/server/config.ts
@@ -18,6 +18,7 @@ export type AdminConfig = {
   minDonationAmount: number;
   maxDonationAmount: number;
   donorSelectionPolicy: DonorSelectionPolicy;
+  referralBonusPoints: number;
   iosRequiredVersion: string;
   androidRequiredVersion: string;
   iosStoreUrl: string | null;
@@ -33,6 +34,7 @@ export const DEFAULT_ADMIN_CONFIG: AdminConfig = {
   minDonationAmount: 10,
   maxDonationAmount: 500,
   donorSelectionPolicy: "least_utilized",
+  referralBonusPoints: 25,
   iosRequiredVersion: "1.0.0",
   androidRequiredVersion: "1.0.0",
   iosStoreUrl: null,
@@ -110,6 +112,7 @@ function rowToConfig(row: typeof adminConfig.$inferSelect): AdminConfig {
     minDonationAmount: row.minDonationAmount,
     maxDonationAmount: row.maxDonationAmount,
     donorSelectionPolicy: normalizeDonorSelectionPolicy(row.donorSelectionPolicy),
+    referralBonusPoints: row.referralBonusPoints,
     iosRequiredVersion: normalizeVersion("iosRequiredVersion", row.iosRequiredVersion),
     androidRequiredVersion: normalizeVersion(
       "androidRequiredVersion",
@@ -211,6 +214,13 @@ export async function updateAdminConfig(
     );
   }
 
+  if (updates.referralBonusPoints !== undefined) {
+    merged.referralBonusPoints = normalizeNonNegativeInteger(
+      "referralBonusPoints",
+      updates.referralBonusPoints
+    );
+  }
+
   if (updates.iosRequiredVersion !== undefined) {
     merged.iosRequiredVersion = normalizeVersion(
       "iosRequiredVersion",
@@ -254,6 +264,7 @@ export async function updateAdminConfig(
         minDonationAmount: merged.minDonationAmount,
         maxDonationAmount: merged.maxDonationAmount,
         donorSelectionPolicy: merged.donorSelectionPolicy,
+        referralBonusPoints: merged.referralBonusPoints,
         iosRequiredVersion: merged.iosRequiredVersion,
         androidRequiredVersion: merged.androidRequiredVersion,
         iosStoreUrl: merged.iosStoreUrl,

--- a/apps/dashboard/lib/server/schema.ts
+++ b/apps/dashboard/lib/server/schema.ts
@@ -1,10 +1,13 @@
-import { pgTable, uuid, text, timestamp, decimal, integer } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, decimal, integer, boolean } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
   id: uuid("id").primaryKey(),
   email: text("email").notNull().unique(),
   name: text("name"),
   avatarUrl: text("avatar_url"),
+  referralCode: text("referral_code").unique(),
+  referredBy: uuid("referred_by").references((): any => users.id),
+  referralBonusApplied: boolean("referral_bonus_applied").notNull().default(false),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
@@ -111,6 +114,7 @@ export const adminConfig = pgTable("admin_config", {
   donorSelectionPolicy: text("donor_selection_policy")
     .notNull()
     .default("least_utilized"),
+  referralBonusPoints: integer("referral_bonus_points").notNull().default(25),
   iosRequiredVersion: text("ios_required_version").notNull().default("1.0.0"),
   androidRequiredVersion: text("android_required_version").notNull().default("1.0.0"),
   iosStoreUrl: text("ios_store_url"),

--- a/apps/dashboard/lib/server/schema.ts
+++ b/apps/dashboard/lib/server/schema.ts
@@ -102,6 +102,13 @@ export const getCredentials = pgTable("get_credentials", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
+export const referralFingerprints = pgTable("referral_fingerprints", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  referralCode: text("referral_code").notNull(),
+  ipAddress: text("ip_address").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
 export const adminConfig = pgTable("admin_config", {
   id: text("id").primaryKey().default("global"),
   defaultWeeklyAllowance: integer("default_weekly_allowance").notNull().default(50),

--- a/apps/mobile/app/(tabs)/(request)/index.tsx
+++ b/apps/mobile/app/(tabs)/(request)/index.tsx
@@ -4,7 +4,7 @@ import { BlurView } from 'expo-blur';
 import { SymbolView } from 'expo-symbols';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { supabase } from '../../../../../lib/supabase';
-import { getRequesterAllowance, generateClaimCode, getClaimHistory, refreshClaimCode, checkRedemption, getReferralInfo, applyReferralCode, type CheckoutRail, type ReferralInfo } from '../../../../../lib/api';
+import { getRequesterAllowance, generateClaimCode, getClaimHistory, refreshClaimCode, checkRedemption, getReferralInfo, applyReferralCode, matchReferralFingerprint, type CheckoutRail, type ReferralInfo } from '../../../../../lib/api';
 import { PDF417Barcode } from '../../../components/PDF417Barcode';
 import { useTabCache } from '../../../../../lib/tab-cache-context';
 
@@ -66,6 +66,7 @@ export default function RequesterScreen() {
   const [timeRemaining, setTimeRemaining] = useState<string>('');
   const [refreshingCode, setRefreshingCode] = useState(false);
   const refreshingCodeRef = useRef(false);
+  const fingerprintChecked = useRef(false);
   const [isRefreshingData, setIsRefreshingData] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [redemptionInfo, setRedemptionInfo] = useState<{
@@ -189,6 +190,18 @@ export default function RequesterScreen() {
 
       const referral = await getReferralInfo();
       setReferralInfo(referral);
+
+      if (!referral.hasAppliedReferralCode && !fingerprintChecked.current) {
+        fingerprintChecked.current = true;
+        try {
+          const match = await matchReferralFingerprint();
+          if (match.referralCode) {
+            setReferralCodeInput(match.referralCode);
+          }
+        } catch {
+          // Best-effort — silently ignore if match fails
+        }
+      }
     } catch (error) {
       console.error('Error loading allowance:', error);
       Alert.alert('Error', 'Failed to load your allowance data');
@@ -234,8 +247,11 @@ export default function RequesterScreen() {
   const handleShareReferral = async () => {
     if (!referralInfo) return;
     try {
+      const apiBase = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000';
+      const referralUrl = `${apiBase}/r/${referralInfo.referralCode}`;
       await Share.share({
-        message: `Join SlugSwap and get free dining points! Use my referral code ${referralInfo.referralCode} when you sign up. Download the app and enter the code to earn bonus points.`,
+        message: `Join SlugSwap and get free dining points! ${referralUrl}`,
+        url: referralUrl,
       });
     } catch (error: any) {
       console.warn('Share failed:', error?.message);

--- a/apps/mobile/app/(tabs)/(request)/index.tsx
+++ b/apps/mobile/app/(tabs)/(request)/index.tsx
@@ -1,10 +1,10 @@
-import { View, Text, Pressable, ScrollView, ActivityIndicator, Alert, PlatformColor, RefreshControl } from 'react-native';
+import { View, Text, Pressable, ScrollView, ActivityIndicator, Alert, PlatformColor, RefreshControl, Share, TextInput } from 'react-native';
 import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
 import { BlurView } from 'expo-blur';
 import { SymbolView } from 'expo-symbols';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { supabase } from '../../../../../lib/supabase';
-import { getRequesterAllowance, generateClaimCode, getClaimHistory, refreshClaimCode, checkRedemption, type CheckoutRail } from '../../../../../lib/api';
+import { getRequesterAllowance, generateClaimCode, getClaimHistory, refreshClaimCode, checkRedemption, getReferralInfo, applyReferralCode, type CheckoutRail, type ReferralInfo } from '../../../../../lib/api';
 import { PDF417Barcode } from '../../../components/PDF417Barcode';
 import { useTabCache } from '../../../../../lib/tab-cache-context';
 
@@ -72,6 +72,9 @@ export default function RequesterScreen() {
     amount: number;
     accountName?: string;
   } | null>(null);
+  const [referralInfo, setReferralInfo] = useState<ReferralInfo | null>(null);
+  const [referralCodeInput, setReferralCodeInput] = useState('');
+  const [applyingReferral, setApplyingReferral] = useState(false);
   const redeemedRail = inferCheckoutRail(redemptionInfo?.accountName);
   const activeCheckoutRail: CheckoutRail = currentCode?.recommendedRail ?? 'points-or-bucks';
   const checkoutInstruction =
@@ -183,6 +186,9 @@ export default function RequesterScreen() {
 
       const historyData = await getClaimHistory(user.id);
       setClaimHistory(historyData.claims);
+
+      const referral = await getReferralInfo();
+      setReferralInfo(referral);
     } catch (error) {
       console.error('Error loading allowance:', error);
       Alert.alert('Error', 'Failed to load your allowance data');
@@ -222,6 +228,37 @@ export default function RequesterScreen() {
       Alert.alert('Error', error.message || 'Failed to generate claim code');
     } finally {
       setGenerating(false);
+    }
+  };
+
+  const handleShareReferral = async () => {
+    if (!referralInfo) return;
+    try {
+      await Share.share({
+        message: `Join SlugSwap and get free dining points! Use my referral code ${referralInfo.referralCode} when you sign up. Download the app and enter the code to earn bonus points.`,
+      });
+    } catch (error: any) {
+      console.warn('Share failed:', error?.message);
+    }
+  };
+
+  const handleApplyReferral = async () => {
+    const code = referralCodeInput.trim().toUpperCase();
+    if (!code) {
+      Alert.alert('Enter a code', 'Please enter a referral code first.');
+      return;
+    }
+    setApplyingReferral(true);
+    try {
+      const result = await applyReferralCode(code);
+      setReferralCodeInput('');
+      Alert.alert('Code Applied!', result.message);
+      const updated = await getReferralInfo();
+      setReferralInfo(updated);
+    } catch (error: any) {
+      Alert.alert('Error', error.message || 'Failed to apply referral code');
+    } finally {
+      setApplyingReferral(false);
     }
   };
 
@@ -462,6 +499,128 @@ export default function RequesterScreen() {
             ))
           )}
         </View>
+
+        {/* Referral Card */}
+        <Card>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+            <SymbolView name="person.2.fill" tintColor={PlatformColor('systemPurple')} size={18} />
+            <Text style={{ fontSize: 17, fontWeight: '600', color: PlatformColor('label') }}>
+              Refer Friends
+            </Text>
+          </View>
+          <Text style={{ fontSize: 13, color: PlatformColor('secondaryLabel'), marginBottom: 16 }}>
+            {referralInfo
+              ? `Earn ${referralInfo.bonusPointsPerReferral} bonus points for every friend who joins.`
+              : 'Earn bonus points for every friend who joins.'}
+          </Text>
+
+          {referralInfo ? (
+            <>
+              <Text style={{ fontSize: 12, color: PlatformColor('tertiaryLabel'), marginBottom: 6 }}>
+                YOUR CODE
+              </Text>
+              <View style={{ flexDirection: 'row', gap: 10, alignItems: 'center', marginBottom: 16 }}>
+                <View style={{
+                  flex: 1,
+                  backgroundColor: PlatformColor('tertiarySystemFill'),
+                  borderRadius: 10,
+                  borderCurve: 'continuous',
+                  paddingVertical: 10,
+                  paddingHorizontal: 14,
+                }}>
+                  <Text selectable style={{
+                    fontSize: 20,
+                    fontWeight: '700',
+                    letterSpacing: 4,
+                    color: PlatformColor('systemPurple'),
+                    fontFamily: 'Menlo',
+                  }}>
+                    {referralInfo.referralCode}
+                  </Text>
+                </View>
+                <Pressable
+                  onPress={handleShareReferral}
+                  style={({ pressed }) => ({
+                    paddingVertical: 10,
+                    paddingHorizontal: 16,
+                    borderRadius: 10,
+                    borderCurve: 'continuous',
+                    backgroundColor: PlatformColor('systemPurple'),
+                    opacity: pressed ? 0.7 : 1,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 6,
+                  })}
+                >
+                  <SymbolView name="square.and.arrow.up" tintColor="#fff" size={14} />
+                  <Text style={{ color: '#fff', fontSize: 14, fontWeight: '600' }}>Share</Text>
+                </Pressable>
+              </View>
+
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 16 }}>
+                <SymbolView name="person.badge.plus" tintColor={PlatformColor('secondaryLabel')} size={14} />
+                <Text style={{ fontSize: 14, color: PlatformColor('secondaryLabel') }}>
+                  {referralInfo.referralCount === 0
+                    ? 'No friends referred yet'
+                    : `${referralInfo.referralCount} ${referralInfo.referralCount === 1 ? 'friend' : 'friends'} referred · ${referralInfo.referralCount * referralInfo.bonusPointsPerReferral} pts earned`}
+                </Text>
+              </View>
+
+              {!referralInfo.hasAppliedReferralCode && (
+                <>
+                  <View style={{ height: 1, backgroundColor: PlatformColor('separator'), marginBottom: 16 }} />
+                  <Text style={{ fontSize: 12, color: PlatformColor('tertiaryLabel'), marginBottom: 8 }}>
+                    HAVE A CODE? ENTER IT BELOW
+                  </Text>
+                  <View style={{ flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+                    <TextInput
+                      value={referralCodeInput}
+                      onChangeText={(t) => setReferralCodeInput(t.toUpperCase())}
+                      placeholder="e.g. ABC123"
+                      placeholderTextColor={PlatformColor('placeholderText')}
+                      autoCapitalize="characters"
+                      autoCorrect={false}
+                      maxLength={8}
+                      style={{
+                        flex: 1,
+                        backgroundColor: PlatformColor('tertiarySystemFill'),
+                        borderRadius: 10,
+                        borderCurve: 'continuous',
+                        paddingVertical: 10,
+                        paddingHorizontal: 14,
+                        fontSize: 16,
+                        fontWeight: '600',
+                        letterSpacing: 2,
+                        color: PlatformColor('label'),
+                        fontFamily: 'Menlo',
+                      }}
+                    />
+                    <Pressable
+                      onPress={handleApplyReferral}
+                      disabled={applyingReferral || referralCodeInput.trim().length === 0}
+                      style={({ pressed }) => ({
+                        paddingVertical: 10,
+                        paddingHorizontal: 16,
+                        borderRadius: 10,
+                        borderCurve: 'continuous',
+                        backgroundColor: PlatformColor('systemGreen'),
+                        opacity: pressed ? 0.7 : (applyingReferral || referralCodeInput.trim().length === 0) ? 0.4 : 1,
+                      })}
+                    >
+                      {applyingReferral ? (
+                        <ActivityIndicator color="#fff" />
+                      ) : (
+                        <Text style={{ color: '#fff', fontSize: 14, fontWeight: '600' }}>Apply</Text>
+                      )}
+                    </Pressable>
+                  </View>
+                </>
+              )}
+            </>
+          ) : (
+            <ActivityIndicator color={PlatformColor('systemPurple')} />
+          )}
+        </Card>
       </ScrollView>
   );
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, integer, timestamp, decimal } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, integer, timestamp, decimal, boolean } from "drizzle-orm/pg-core";
 
 // Users table - syncs with Supabase Auth
 export const users = pgTable("users", {
@@ -6,6 +6,9 @@ export const users = pgTable("users", {
   email: text("email").notNull().unique(),
   name: text("name"),
   avatarUrl: text("avatar_url"),
+  referralCode: text("referral_code").unique(), // Unique code this user shares with others
+  referredBy: uuid("referred_by").references((): any => users.id), // ID of user who referred them
+  referralBonusApplied: boolean("referral_bonus_applied").notNull().default(false), // True once referrer has been credited
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
@@ -92,6 +95,7 @@ export const adminConfig = pgTable("admin_config", {
   minDonationAmount: integer("min_donation_amount").notNull().default(10),
   maxDonationAmount: integer("max_donation_amount").notNull().default(500),
   donorSelectionPolicy: text("donor_selection_policy").notNull().default("least_utilized"),
+  referralBonusPoints: integer("referral_bonus_points").notNull().default(25),
   iosRequiredVersion: text("ios_required_version").notNull().default("1.0.0"),
   androidRequiredVersion: text("android_required_version").notNull().default("1.0.0"),
   iosStoreUrl: text("ios_store_url"),

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -84,6 +84,14 @@ export const getCredentials = pgTable("get_credentials", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
+// Referral fingerprints table - short-lived records for deferred deep linking
+export const referralFingerprints = pgTable("referral_fingerprints", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  referralCode: text("referral_code").notNull(),
+  ipAddress: text("ip_address").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
 // Admin config table - persistent global settings
 export const adminConfig = pgTable("admin_config", {
   id: text("id").primaryKey().default("global"),

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -361,6 +361,21 @@ export async function applyReferralCode(referralCode: string): Promise<{ success
   return response.json();
 }
 
+export async function matchReferralFingerprint(): Promise<{ referralCode: string | null }> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`${API_BASE_URL}/api/referrals/match`, {
+    method: 'POST',
+    headers,
+  });
+
+  if (!response.ok) {
+    const errorMessage = await readApiError(response, 'Failed to match referral fingerprint');
+    throw new Error(errorMessage);
+  }
+
+  return response.json();
+}
+
 export async function getMobileAppConfig() {
   const response = await fetch(`${API_BASE_URL}/api/mobile/config`, {
     cache: 'no-store',

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -326,6 +326,41 @@ export async function getUserBalance(params: { name?: string; email?: string; us
   }>;
 }
 
+export type ReferralInfo = {
+  referralCode: string;
+  referralCount: number;
+  bonusPointsPerReferral: number;
+  hasAppliedReferralCode: boolean;
+};
+
+export async function getReferralInfo(): Promise<ReferralInfo> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`${API_BASE_URL}/api/referrals/code`, { headers });
+
+  if (!response.ok) {
+    const errorMessage = await readApiError(response, 'Failed to fetch referral info');
+    throw new Error(errorMessage);
+  }
+
+  return response.json() as Promise<ReferralInfo>;
+}
+
+export async function applyReferralCode(referralCode: string): Promise<{ success: boolean; bonusPointsAwarded: number; message: string }> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`${API_BASE_URL}/api/referrals/apply`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ referralCode }),
+  });
+
+  if (!response.ok) {
+    const errorMessage = await readApiError(response, 'Failed to apply referral code');
+    throw new Error(errorMessage);
+  }
+
+  return response.json();
+}
+
 export async function getMobileAppConfig() {
   const response = await fetch(`${API_BASE_URL}/api/mobile/config`, {
     cache: 'no-store',


### PR DESCRIPTION
- Add referralCode, referredBy, referralBonusApplied fields to users table (both schema files)
- Add referralBonusPoints field to adminConfig (default 25 pts per referral)
- New GET /api/referrals/code endpoint: returns user's unique code, referral count, bonus amount, and whether they've applied a code
- New POST /api/referrals/apply endpoint: validates and applies a referral code, credits bonus points to referrer's current-week allowance
- Referral codes are 6-char alphanumeric (visually unambiguous charset), generated lazily on first request
- Add getReferralInfo() and applyReferralCode() to mobile API client
- Add Referral card to requester screen: shows shareable code, referral count/earnings, and optional code-entry field for new users

https://claude.ai/code/session_01Pba4jZtJYugrb5aoCaKxMW