### PR TITLE
Add admin endpoint to retrieve GET transaction history

### DIFF
--- a/apps/dashboard/app/api/admin/[action]/route.ts
+++ b/apps/dashboard/app/api/admin/[action]/route.ts
@@ -10,7 +10,7 @@ import {
 import { getDonorWeeklyUsageMap } from "@/lib/server/claims/donor-usage";
 import { getPacificWeekWindow } from "@/lib/server/timezone";
 import { getActiveGetSession } from "@/lib/server/get/session";
-import { retrieveAccounts } from "@/lib/server/get/tools";
+import { retrieveAccounts, retrieveTransactionHistory } from "@/lib/server/get/tools";
 import {
   authenticateAdminBearerToken,
   clearAdminSessionCookie,
@@ -813,6 +813,67 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
       );
     } catch (error: any) {
       console.error("Error fetching user balance:", error);
+      return NextResponse.json(
+        { error: error?.message || "Internal server error" },
+        { status: 500 }
+      );
+    }
+  }
+
+  if (action === "get-transaction-history") {
+    if (req.method !== "GET") {
+      return NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    try {
+      const url = new URL(req.url);
+      const userId = url.searchParams.get("userId");
+      const startDate = url.searchParams.get("startDate") ?? undefined;
+      const endDate = url.searchParams.get("endDate") ?? undefined;
+      const maxRows = url.searchParams.get("limit")
+        ? Math.min(500, Math.max(1, parseInt(url.searchParams.get("limit")!, 10)))
+        : 100;
+
+      if (!userId) {
+        return NextResponse.json({ error: "userId is required" }, { status: 400 });
+      }
+
+      const user = await db.query.users.findFirst({
+        where: eq(schema.users.id, userId),
+      });
+      if (!user) {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+      }
+
+      const getCredential = await db.query.getCredentials.findFirst({
+        where: eq(schema.getCredentials.userId, userId),
+      });
+      if (!getCredential) {
+        return NextResponse.json(
+          { error: "User does not have a linked GET account" },
+          { status: 404 }
+        );
+      }
+
+      const { sessionId } = await getActiveGetSession(userId);
+      const transactions = await retrieveTransactionHistory(sessionId, {
+        startDate,
+        endDate,
+        maxNumberOfRows: maxRows,
+      });
+
+      return NextResponse.json(
+        {
+          userId,
+          user: { id: user.id, email: user.email, name: user.name },
+          transactions,
+          count: transactions.length,
+          filters: { startDate: startDate ?? null, endDate: endDate ?? null, limit: maxRows },
+        },
+        { status: 200 }
+      );
+    } catch (error: any) {
+      console.error("Error fetching GET transaction history:", error);
       return NextResponse.json(
         { error: error?.message || "Internal server error" },
         { status: 500 }

--- a/apps/dashboard/lib/server/get/tools.ts
+++ b/apps/dashboard/lib/server/get/tools.ts
@@ -199,3 +199,41 @@ export async function revokePin(sessionId: string, deviceId: string) {
     throw new GetApiError("GET deletePIN failed");
   }
 }
+
+export type GetTransaction = {
+  actualDate: string | null;
+  amount: number;
+  balance: number | null;
+  description: string | null;
+  friendlyDescription: string | null;
+  locationName: string | null;
+  paymentSystemType: number | null;
+  tenderName: string;
+  transactionDate: string;
+};
+
+export async function retrieveTransactionHistory(
+  sessionId: string,
+  options?: {
+    startDate?: string;
+    endDate?: string;
+    maxNumberOfRows?: number;
+    paymentSystemType?: number;
+  }
+): Promise<GetTransaction[]> {
+  const raw = await callGetApi<
+    {
+      sessionId: string;
+      startDate?: string;
+      endDate?: string;
+      maxNumberOfRows?: number;
+      paymentSystemType?: number;
+    },
+    GetTransaction[]
+  >("commerce", "retrieveTransactionHistory", {
+    sessionId,
+    ...options,
+  });
+
+  return Array.isArray(raw) ? raw : [];
+}


### PR DESCRIPTION
## Summary
This PR adds a new admin API endpoint that allows retrieving transaction history for users with linked GET accounts. It includes a new `retrieveTransactionHistory` function that wraps the GET API and a corresponding admin action handler.

## Key Changes
- **New API endpoint**: Added `get-transaction-history` admin action that accepts `userId`, `startDate`, `endDate`, and `limit` query parameters
- **New function**: Implemented `retrieveTransactionHistory()` in `lib/server/get/tools.ts` to call the GET API's commerce service
- **Type definition**: Added `GetTransaction` type to represent transaction data returned from the GET API
- **Validation**: Endpoint validates that the user exists and has a linked GET account before retrieving transactions
- **Rate limiting**: Enforces a maximum of 500 rows per request (default 100) to prevent excessive data retrieval

## Implementation Details
- The endpoint performs user and credential validation before making the GET API call
- Transaction limit is clamped between 1 and 500 to ensure reasonable request sizes
- Response includes user metadata, transaction list, count, and applied filters for transparency
- Error handling covers missing users, missing GET credentials, and API failures with appropriate HTTP status codes

https://claude.ai/code/session_011GoHnihbrCFfVUxE68uuor