### PR TITLE
Root chaos landing + same-domain /app integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,13 @@ npm run dashboard:dev          # Start Next.js dashboard (port 3000)
 npm run dashboard:dev -- -p 3001  # Dashboard on custom port (useful when mobile needs 3000)
 ```
 
+### Web Routes (single-domain deployment)
+- `/` — public landing page
+- `/app` — Expo web client (exported static bundle served by Next.js)
+- `/admin/login` — admin login
+- `/admin` — admin dashboard
+- `/api/*` — API endpoints
+
 ### Database (Drizzle)
 ```bash
 npm run db:generate            # Generate migrations from schema changes
@@ -42,6 +49,8 @@ npm run mobile:eas:testflight  # Build iOS + submit to TestFlight
 npm run mobile:eas:update      # OTA update to production channel
 ```
 
+`apps/dashboard` build now exports Expo web assets into `apps/dashboard/public/app` before `next build`.
+
 ### Troubleshooting
 ```bash
 npx expo-doctor                # Check for dependency issues, version mismatches, and configuration problems
@@ -55,10 +64,11 @@ No test framework is configured. No linter is configured.
 
 ### Monorepo Structure (npm workspaces)
 - `apps/mobile/` — Expo Router (React Native) mobile app
-- `apps/dashboard/` — Next.js 15 App Router: admin dashboard UI **and** all API routes
+- `apps/dashboard/` — Next.js 15 App Router: public landing, admin UI, Expo web host (`/app`), and all API routes
 - `db/` — Drizzle ORM schema (`schema.ts`), migrations, and DB connection (`index.ts`)
 - `lib/` — Shared client-side code (Supabase client, auth context, mobile API client)
 - `packages/` — Empty (reserved for future shared packages)
+- `landing-pages-react/` — Design lab/reference pages (not production-routed)
 
 ### API Layer
 All API routes live in `apps/dashboard/app/api/`. They use a **dynamic route segment + dispatcher** pattern:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Start the dashboard app:
 npm run dashboard:dev -- -p 3001
 ```
 
+Route map (dashboard app):
+- `/` -> public landing page
+- `/app` -> Expo web app (same domain)
+- `/admin/login` -> admin login
+- `/admin` -> admin dashboard
+- `/api/*` -> backend API routes
+
 Deploy dashboard preview:
 
 ```bash
@@ -74,6 +81,10 @@ slugswap/
 ├── scripts/                # Project scripts
 └── .github/workflows/      # CI/CD workflows
 ```
+
+### Landing Design Lab
+
+`landing-pages-react/` stays as a design/reference workspace and is not used for production routing.
 
 ## Product Releases
 

--- a/apps/dashboard/app/admin-dashboard-client.tsx
+++ b/apps/dashboard/app/admin-dashboard-client.tsx
@@ -316,7 +316,7 @@ export default function DashboardHomePage() {
       ]);
 
       if (statsRes.status === 401 || configRes.status === 401) {
-        router.replace("/login");
+        router.replace("/admin/login");
         return;
       }
 
@@ -356,7 +356,7 @@ export default function DashboardHomePage() {
     try {
       const res = await fetch("/api/admin/users?limit=100", { cache: "no-store" });
       if (res.status === 401) {
-        router.replace("/login");
+        router.replace("/admin/login");
         return;
       }
       if (!res.ok) {
@@ -378,7 +378,7 @@ export default function DashboardHomePage() {
           cache: "no-store",
         });
         if (res.status === 401) {
-          router.replace("/login");
+          router.replace("/admin/login");
           return;
         }
         if (!res.ok) {
@@ -531,7 +531,7 @@ export default function DashboardHomePage() {
       });
 
       if (res.status === 401) {
-        router.replace("/login");
+        router.replace("/admin/login");
         return;
       }
 
@@ -556,7 +556,7 @@ export default function DashboardHomePage() {
     try {
       await fetch("/api/admin/logout", { method: "POST" });
     } finally {
-      window.location.assign("/login?logout=1");
+      window.location.assign("/admin/login?logout=1");
       setIsLoggingOut(false);
     }
   }, []);
@@ -585,7 +585,7 @@ export default function DashboardHomePage() {
       });
 
       if (res.status === 401) {
-        router.replace("/login");
+        router.replace("/admin/login");
         return;
       }
 
@@ -620,7 +620,7 @@ export default function DashboardHomePage() {
       });
 
       if (res.status === 401) {
-        router.replace("/login");
+        router.replace("/admin/login");
         return;
       }
 

--- a/apps/dashboard/app/admin/login/login-client.tsx
+++ b/apps/dashboard/app/admin/login/login-client.tsx
@@ -76,7 +76,7 @@ export default function AdminLoginClient({ supabaseUrl, supabaseAnonKey }: Login
           return;
         }
 
-        router.replace("/");
+        router.replace("/admin");
         router.refresh();
       } catch {
         setError("Unable to reach server");
@@ -147,7 +147,7 @@ export default function AdminLoginClient({ supabaseUrl, supabaseAnonKey }: Login
       const { error: signInError } = await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: `${window.location.origin}/login`,
+          redirectTo: `${window.location.origin}/admin/login`,
         },
       });
 

--- a/apps/dashboard/app/admin/login/login-client.tsx
+++ b/apps/dashboard/app/admin/login/login-client.tsx
@@ -29,7 +29,8 @@ async function readError(response: Response): Promise<string> {
 export default function AdminLoginClient({ supabaseUrl, supabaseAnonKey }: LoginProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const exchangeInFlightRef = useRef(false);
+const exchangeInFlightRef = useRef(false);
+const OAUTH_TARGET_KEY = "slugswap_oauth_target";
 
   const [isCheckingSession, setIsCheckingSession] = useState(true);
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -74,6 +75,10 @@ export default function AdminLoginClient({ supabaseUrl, supabaseAnonKey }: Login
             setError(message);
           }
           return;
+        }
+
+        if (typeof window !== "undefined") {
+          window.localStorage.removeItem(OAUTH_TARGET_KEY);
         }
 
         router.replace("/admin");
@@ -144,6 +149,10 @@ export default function AdminLoginClient({ supabaseUrl, supabaseAnonKey }: Login
     setIsRedirecting(true);
 
     try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(OAUTH_TARGET_KEY, "admin");
+      }
+
       const { error: signInError } = await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {

--- a/apps/dashboard/app/admin/login/page.tsx
+++ b/apps/dashboard/app/admin/login/page.tsx
@@ -1,0 +1,27 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { ADMIN_SESSION_COOKIE, verifyAdminSessionToken } from "@/lib/server/admin-auth";
+import AdminLoginClient from "./login-client";
+
+export default async function AdminLoginPage() {
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(ADMIN_SESSION_COOKIE)?.value;
+
+  let isAuthenticated = false;
+  try {
+    isAuthenticated = verifyAdminSessionToken(sessionToken);
+  } catch {
+    isAuthenticated = false;
+  }
+
+  if (isAuthenticated) {
+    redirect("/admin");
+  }
+
+  return (
+    <AdminLoginClient
+      supabaseUrl={process.env.EXPO_PUBLIC_SUPABASE_URL ?? ""}
+      supabaseAnonKey={process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? ""}
+    />
+  );
+}

--- a/apps/dashboard/app/admin/page.tsx
+++ b/apps/dashboard/app/admin/page.tsx
@@ -1,27 +1,22 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import DashboardHomePage from "../admin-dashboard-client";
 import { ADMIN_SESSION_COOKIE, verifyAdminSessionToken } from "@/lib/server/admin-auth";
-import AdminLoginClient from "./login-client";
 
-export default async function AdminLoginPage() {
+export default async function Page() {
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(ADMIN_SESSION_COOKIE)?.value;
-
   let isAuthenticated = false;
+
   try {
     isAuthenticated = verifyAdminSessionToken(sessionToken);
   } catch {
     isAuthenticated = false;
   }
 
-  if (isAuthenticated) {
-    redirect("/");
+  if (!isAuthenticated) {
+    redirect("/admin/login");
   }
 
-  return (
-    <AdminLoginClient
-      supabaseUrl={process.env.EXPO_PUBLIC_SUPABASE_URL ?? ""}
-      supabaseAnonKey={process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? ""}
-    />
-  );
+  return <DashboardHomePage />;
 }

--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -1,3 +1,5 @@
+@import "tailwindcss";
+
 html,
 body {
   margin: 0;

--- a/apps/dashboard/app/landing-client.tsx
+++ b/apps/dashboard/app/landing-client.tsx
@@ -194,13 +194,20 @@ export default function LandingClient({
     if (typeof window === "undefined") return;
 
     const { pathname, search, hash } = window.location;
+    const searchParams = new URLSearchParams(search);
+    const oauthTarget = window.localStorage.getItem("slugswap_oauth_target");
     const hasOAuthPayload =
       hash.includes("access_token=") ||
       hash.includes("refresh_token=") ||
-      search.includes("code=") ||
-      search.includes("error=");
+      searchParams.has("code") ||
+      searchParams.has("error");
 
     if (pathname === "/" && hasOAuthPayload) {
+      if (oauthTarget === "admin") {
+        window.localStorage.removeItem("slugswap_oauth_target");
+        window.location.replace(`/admin/login${search}${hash}`);
+        return;
+      }
       window.location.replace(`/app/auth/callback${search}${hash}`);
     }
   }, []);

--- a/apps/dashboard/app/landing-client.tsx
+++ b/apps/dashboard/app/landing-client.tsx
@@ -480,62 +480,9 @@ export default function LandingClient({
           </div>
         </div>
 
-        <div className="mx-auto mb-20 max-w-7xl">
-          <div className="relative">
-            {[
-              {
-                quote: '"I had points expiring. Now they feed people!"',
-                name: "MAYA",
-                color: "#f7dc6f",
-                rotate: -2,
-                top: 0,
-                left: 0,
-              },
-              {
-                quote: '"No more choosing textbooks over meals!"',
-                name: "JORDAN",
-                color: "#4ecdc4",
-                rotate: 3,
-                top: 120,
-                left: 200,
-              },
-              {
-                quote: '"Most equitable system on campus."',
-                name: "ALEX",
-                color: "#e74c3c",
-                rotate: -1,
-                top: 240,
-                left: 100,
-              },
-            ].map((test, i) => (
-              <motion.div
-                key={`${test.name}-${i}`}
-                initial={{ opacity: 0, scale: 0.8 }}
-                whileInView={{ opacity: 1, scale: 1 }}
-                viewport={{ once: true }}
-                transition={{ delay: i * 0.2 }}
-                whileHover={{ scale: 1.1, rotate: 0, zIndex: 50 }}
-                className="absolute max-w-md border-8 border-black p-8 md:relative"
-                style={{
-                  transform: `rotate(${test.rotate}deg)`,
-                  top: test.top,
-                  left: test.left,
-                  backgroundColor: test.color,
-                  marginBottom: i < 2 ? "80px" : "0",
-                }}
-              >
-                <p className="mb-4 text-2xl font-black" style={{ fontFamily: "Impact, sans-serif" }}>
-                  {test.quote}
-                </p>
-                <p className="text-xl font-bold" style={{ fontFamily: "Arial Black, sans-serif" }}>
-                  {test.name}
-                </p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
+        {/* Placeholder testimonials disabled for now. */}
 
-        <div className="mx-auto mb-20 mt-[500px] max-w-5xl text-center md:mt-20">
+        <div className="mx-auto mb-20 mt-20 max-w-5xl text-center">
           <motion.div initial={{ scale: 0 }} whileInView={{ scale: 1 }} viewport={{ once: true }} className="relative">
             <div className="relative z-20 border-8 border-[#f7dc6f] bg-black p-16 text-white">
               <h2 className="mb-8 text-5xl font-black md:text-8xl" style={{ fontFamily: "Impact, sans-serif" }}>

--- a/apps/dashboard/app/landing-client.tsx
+++ b/apps/dashboard/app/landing-client.tsx
@@ -1,0 +1,576 @@
+"use client";
+
+import { motion, useAnimationControls } from "framer-motion";
+import { Apple, ArrowRight, Chrome, Smartphone } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+type LandingClientProps = {
+  pointsDistributed: number;
+  activeDonors: number;
+  asOf: string;
+  iosStoreUrl: string | null;
+  androidStoreUrl: string | null;
+};
+
+const CHAOS_COLORS = ["#4ecdc4", "#f7dc6f", "#e74c3c", "#9b59b6", "#2ecc71"] as const;
+
+const CHAOS_BLOBS = [
+  { size: 180, left: "6%", top: "5%", color: "#4ecdc4", dx: -36, dy: 18, rotate: 120, scale: 0.8 },
+  { size: 130, left: "18%", top: "28%", color: "#f7dc6f", dx: 30, dy: -24, rotate: -80, scale: 1.1 },
+  { size: 220, left: "70%", top: "7%", color: "#e74c3c", dx: -22, dy: 20, rotate: 145, scale: 0.75 },
+  { size: 95, left: "83%", top: "33%", color: "#9b59b6", dx: 16, dy: -16, rotate: -160, scale: 1.2 },
+  { size: 150, left: "4%", top: "66%", color: "#2ecc71", dx: 24, dy: -12, rotate: 105, scale: 0.9 },
+  { size: 110, left: "40%", top: "80%", color: "#f7dc6f", dx: -20, dy: -14, rotate: -100, scale: 1.15 },
+  { size: 170, left: "76%", top: "68%", color: "#4ecdc4", dx: 28, dy: 22, rotate: 132, scale: 0.8 },
+  { size: 120, left: "54%", top: "16%", color: "#2ecc71", dx: -18, dy: 26, rotate: -124, scale: 1.05 },
+  { size: 200, left: "28%", top: "48%", color: "#9b59b6", dx: 22, dy: -24, rotate: 98, scale: 0.7 },
+  { size: 160, left: "62%", top: "44%", color: "#e74c3c", dx: -30, dy: 14, rotate: -140, scale: 0.95 },
+] as const;
+
+const FLOATERS = [
+  { size: 54, left: "11%", top: "14%", color: "#4ecdc4", round: true, drift: -22 },
+  { size: 68, left: "29%", top: "89%", color: "#f7dc6f", round: false, drift: -30 },
+  { size: 58, left: "44%", top: "11%", color: "#e74c3c", round: true, drift: -20 },
+  { size: 66, left: "62%", top: "85%", color: "#9b59b6", round: false, drift: -26 },
+  { size: 48, left: "86%", top: "17%", color: "#2ecc71", round: true, drift: -18 },
+  { size: 64, left: "79%", top: "51%", color: "#f7dc6f", round: false, drift: -24 },
+  { size: 56, left: "18%", top: "56%", color: "#2ecc71", round: true, drift: -28 },
+  { size: 50, left: "84%", top: "76%", color: "#e74c3c", round: true, drift: -16 },
+] as const;
+
+type FloaterItem = (typeof FLOATERS)[number];
+
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatAsOf(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "just now";
+  return parsed.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function CtaButton({
+  href,
+  disabled,
+  bg,
+  text,
+  rotate,
+  children,
+}: {
+  href?: string;
+  disabled?: boolean;
+  bg: string;
+  text: string;
+  rotate: string;
+  children: ReactNode;
+}) {
+  const className = `inline-flex items-center justify-center gap-2 border-8 border-black font-black text-xl px-8 py-5 h-auto transform ${rotate} shadow-[8px_8px_0_#000]`;
+
+  if (!href || disabled) {
+    return (
+      <button
+        type="button"
+        disabled
+        className={`${className} ${bg} text-black opacity-55 cursor-not-allowed`}
+        style={{ fontFamily: "Impact, sans-serif" }}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  const external = href.startsWith("http://") || href.startsWith("https://");
+
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className={`${className} ${bg} ${text}`}
+        style={{ fontFamily: "Impact, sans-serif" }}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={`${className} ${bg} ${text}`} style={{ fontFamily: "Impact, sans-serif" }}>
+      {children}
+    </Link>
+  );
+}
+
+function CursorFloater({
+  item,
+  i,
+}: {
+  item: FloaterItem;
+  i: number;
+}) {
+  const controls = useAnimationControls();
+
+  const triggerBounce = () =>
+    controls.start({
+      y: [0, 18, -22, 10, 0],
+      rotate: item.round ? [0, 0, 0, 0, 0] : [0, 22, -16, 8, 0],
+      transition: {
+        duration: 0.62,
+        times: [0, 0.2, 0.46, 0.72, 1],
+        ease: "easeOut",
+      },
+    });
+
+  return (
+    <motion.div
+      className="absolute"
+      style={{
+        left: item.left,
+        top: item.top,
+      }}
+      animate={controls}
+      whileHover={{
+        scale: 1.14,
+        y: -14,
+        rotate: item.round ? 0 : 14,
+        transition: { type: "spring", stiffness: 360, damping: 18, mass: 0.28 },
+      }}
+      whileTap={{ scale: 0.9 }}
+      onHoverStart={() => {
+        void triggerBounce();
+      }}
+      onTapStart={() => {
+        void triggerBounce();
+      }}
+    >
+      <motion.div
+        className="border-4 border-black"
+        style={{
+          width: item.size,
+          height: item.size,
+          backgroundColor: item.color,
+          borderRadius: item.round ? "50%" : "0",
+        }}
+        animate={{
+          y: [0, item.drift, 0],
+          rotate: [0, 360],
+        }}
+        transition={{
+          duration: 6 + i,
+          repeat: Number.POSITIVE_INFINITY,
+          delay: i * 0.2,
+        }}
+      />
+    </motion.div>
+  );
+}
+
+export default function LandingClient({
+  pointsDistributed,
+  activeDonors,
+  asOf,
+  iosStoreUrl,
+  androidStoreUrl,
+}: LandingClientProps) {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const { pathname, search, hash } = window.location;
+    const hasOAuthPayload =
+      hash.includes("access_token=") ||
+      hash.includes("refresh_token=") ||
+      search.includes("code=") ||
+      search.includes("error=");
+
+    if (pathname === "/" && hasOAuthPayload) {
+      window.location.replace(`/app/auth/callback${search}${hash}`);
+    }
+  }, []);
+
+  const lastUpdated = formatAsOf(asOf);
+
+  return (
+    <div className="relative min-h-screen overflow-x-clip bg-[#ff6b35] text-black">
+      <div className="absolute inset-0 opacity-20">
+        {CHAOS_BLOBS.map((blob, i) => (
+          <motion.div
+            key={`${blob.left}-${blob.top}`}
+            className="absolute rounded-full"
+            style={{
+              width: blob.size,
+              height: blob.size,
+              left: blob.left,
+              top: blob.top,
+              background: blob.color,
+            }}
+            animate={{
+              x: [0, blob.dx],
+              y: [0, blob.dy],
+              rotate: [0, blob.rotate],
+              scale: [1, blob.scale, 1],
+            }}
+            transition={{
+              duration: 9 + i,
+              repeat: Number.POSITIVE_INFINITY,
+              ease: "linear",
+            }}
+          />
+        ))}
+      </div>
+
+      <div
+        className="absolute inset-0 opacity-10"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(45deg, transparent, transparent 35px, rgba(0,0,0,0.5) 35px, rgba(0,0,0,0.5) 70px)",
+        }}
+      />
+
+      <div className="relative z-10 px-6 py-12 md:px-12">
+        <motion.div
+          initial={{ opacity: 0, y: -50 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-12 flex flex-wrap items-start justify-between gap-4"
+        >
+          <div className="flex items-center gap-4">
+            <h1 className="text-5xl font-black tracking-tighter text-black" style={{ fontFamily: "Impact, sans-serif" }}>
+              SLUGSWAP
+            </h1>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {["DONATE", "REQUEST", "LIVE STATS"].map((text, i) => (
+              <motion.div
+                key={text}
+                whileHover={{ scale: 1.1, rotate: -5 }}
+                className={`border-4 border-[#4ecdc4] bg-black px-4 py-2 text-sm font-black text-[#f7dc6f] ${i % 2 === 0 ? "-rotate-2" : "rotate-2"}`}
+                style={{ fontFamily: "Arial Black, sans-serif" }}
+              >
+                {text}
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+
+        <div className="mx-auto mb-20 max-w-7xl">
+          <div className="relative mb-14">
+            <motion.div
+              initial={{ x: -100, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              transition={{ duration: 0.8 }}
+              className="relative"
+            >
+              <h2
+                className="relative z-10 -rotate-3 font-black leading-none tracking-tighter text-black [font-size:clamp(4.25rem,17vw,16rem)]"
+                style={{ fontFamily: "Impact, sans-serif", WebkitTextStroke: "4px #fff", paintOrder: "stroke fill" }}
+              >
+                SHARE
+              </h2>
+              <motion.div
+                animate={{ rotate: [0, 5, -5, 0] }}
+                transition={{ duration: 2, repeat: Number.POSITIVE_INFINITY }}
+                className="absolute right-3 top-3 z-0 h-20 w-20 rotate-45 border-8 border-black bg-[#f7dc6f] md:right-8 md:top-2 md:h-40 md:w-40"
+              />
+            </motion.div>
+
+            <motion.div
+              initial={{ x: 100, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              transition={{ duration: 0.8, delay: 0.1 }}
+              className="relative -mt-4 ml-6 md:-mt-20 md:ml-20"
+            >
+              <h2
+                className="rotate-2 font-black leading-none tracking-tighter text-[#4ecdc4] [font-size:clamp(4rem,16.2vw,15.8rem)]"
+                style={{ fontFamily: "Impact, sans-serif", WebkitTextStroke: "4px #000", paintOrder: "stroke fill" }}
+              >
+                DINING
+              </h2>
+            </motion.div>
+
+            <motion.div
+              initial={{ x: -100, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              transition={{ duration: 0.8, delay: 0.2 }}
+              className="relative -mt-4 md:-mt-20"
+            >
+              <h2
+                className="-rotate-1 font-black leading-none tracking-tighter text-[#e74c3c] [font-size:clamp(3.95rem,15.8vw,15.5rem)]"
+                style={{ fontFamily: "Impact, sans-serif", WebkitTextStroke: "4px #fff", paintOrder: "stroke fill" }}
+              >
+                POINTS
+              </h2>
+              <motion.div
+                animate={{ scale: [1, 1.2, 1] }}
+                transition={{ duration: 1.5, repeat: Number.POSITIVE_INFINITY }}
+                className="absolute right-1 top-1/2 h-20 w-20 rounded-full border-8 border-black bg-[#9b59b6] md:right-16 md:h-32 md:w-32"
+              />
+            </motion.div>
+          </div>
+
+          <div className="mb-12 grid grid-cols-1 gap-8 md:grid-cols-3">
+            <motion.div
+              whileHover={{ rotate: -2, scale: 1.05 }}
+              className="relative rotate-1 overflow-hidden border-8 border-black bg-[#f7dc6f] p-8"
+            >
+              <div className="absolute -right-4 -top-4 h-24 w-24 rounded-full border-4 border-black bg-[#e74c3c]" />
+              <h3 className="mb-4 text-6xl font-black" style={{ fontFamily: "Impact, sans-serif" }}>
+                {formatCurrency(pointsDistributed)}
+              </h3>
+              <p className="text-xl font-black" style={{ fontFamily: "Arial Black, sans-serif" }}>
+                WORTH OF POINTS DISTRIBUTED
+              </p>
+              <div className="absolute -bottom-2 -left-2 h-16 w-16 rotate-45 bg-black" />
+            </motion.div>
+
+            <motion.div
+              whileHover={{ rotate: 2, scale: 1.05 }}
+              className="relative -rotate-2 border-8 border-black bg-[#4ecdc4] p-8"
+            >
+              <div className="absolute right-0 top-0 h-0 w-0 border-l-[100px] border-l-transparent border-t-[100px] border-t-[#9b59b6]" />
+              <h3 className="relative z-10 mb-4 text-6xl font-black" style={{ fontFamily: "Impact, sans-serif" }}>
+                {formatCount(activeDonors)}
+              </h3>
+              <p className="relative z-10 text-xl font-black" style={{ fontFamily: "Arial Black, sans-serif" }}>
+                ACTIVE DONORS
+              </p>
+            </motion.div>
+
+            <motion.div
+              whileHover={{ rotate: -3, scale: 1.05 }}
+              className="relative rotate-3 border-8 border-black bg-[#2ecc71] p-8"
+            >
+              <motion.div
+                animate={{ rotate: 360 }}
+                transition={{ duration: 8, repeat: Number.POSITIVE_INFINITY, ease: "linear" }}
+                className="absolute -left-8 -top-8 h-24 w-24 border-4 border-black bg-[#f7dc6f]"
+              />
+              <h3 className="mb-4 text-5xl font-black md:text-6xl" style={{ fontFamily: "Impact, sans-serif" }}>
+                LIVE NOW
+              </h3>
+              <p className="text-base font-black md:text-xl" style={{ fontFamily: "Arial Black, sans-serif" }}>
+                UPDATED {lastUpdated.toUpperCase()}
+              </p>
+            </motion.div>
+          </div>
+
+          <div className="relative mb-12">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="relative z-20 -rotate-1 border-8 border-[#f7dc6f] bg-black p-8 text-white"
+            >
+              <p className="text-3xl font-black leading-tight md:text-5xl" style={{ fontFamily: "Impact, sans-serif" }}>
+                FAST. FAIR. SIMPLE.
+              </p>
+            </motion.div>
+            <div className="absolute left-4 top-4 z-10 h-full w-full rotate-2 border-8 border-black bg-[#e74c3c]" />
+            <div className="absolute left-8 top-8 z-0 h-full w-full -rotate-3 border-8 border-black bg-[#4ecdc4]" />
+          </div>
+
+          <div className="flex flex-wrap gap-6">
+            <motion.div whileHover={{ scale: 1.1, rotate: -5 }} whileTap={{ scale: 0.95 }}>
+              <CtaButton href={iosStoreUrl ?? undefined} disabled={!iosStoreUrl} bg="bg-[#e74c3c]" text="text-black" rotate="rotate-2">
+                <Apple className="h-6 w-6" />
+                {iosStoreUrl ? "IOS BETA" : "IOS SOON"}
+                <ArrowRight className="ml-1 h-6 w-6" />
+              </CtaButton>
+            </motion.div>
+
+            <motion.div whileHover={{ scale: 1.1, rotate: 5 }} whileTap={{ scale: 0.95 }}>
+              <CtaButton href="/app" bg="bg-[#f7dc6f]" text="text-black" rotate="-rotate-1">
+                <Chrome className="h-6 w-6" />
+                OPEN WEB APP
+              </CtaButton>
+            </motion.div>
+
+            <motion.div whileHover={{ scale: 1.1, rotate: -4 }} whileTap={{ scale: 0.95 }}>
+              <CtaButton
+                href={androidStoreUrl ?? undefined}
+                disabled={!androidStoreUrl}
+                bg="bg-[#9b59b6]"
+                text="text-black"
+                rotate="rotate-1"
+              >
+                <Smartphone className="h-6 w-6" />
+                {androidStoreUrl ? "ANDROID APP" : "ANDROID SOON"}
+              </CtaButton>
+            </motion.div>
+          </div>
+        </div>
+
+        <div className="mx-auto mb-20 max-w-7xl">
+          <div className="grid grid-cols-1 gap-12 md:grid-cols-2">
+            {[
+              {
+                title: "POOLED SUPPORT",
+                desc: "Your monthly donation splits into weekly pools. Everyone draws from the community fund.",
+                color: "#4ecdc4",
+                rotate: 2,
+              },
+              {
+                title: "FAIR ALLOWANCES",
+                desc: "Equal access to weekly allowance. Reset every week. First-come basis. No judgment.",
+                color: "#f7dc6f",
+                rotate: -3,
+              },
+              {
+                title: "INSTANT CODES",
+                desc: "Generate secure code via GET Tools. Redeem at any dining location. Expires in minutes.",
+                color: "#e74c3c",
+                rotate: 1,
+              },
+              {
+                title: "PRIVACY FIRST",
+                desc: "Donors do not see requesters. Anonymous giving and receiving with dignity.",
+                color: "#2ecc71",
+                rotate: -2,
+              },
+            ].map((feature, i) => (
+              <motion.div
+                key={feature.title}
+                initial={{ opacity: 0, y: 50 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.1 }}
+                whileHover={{ scale: 1.05, rotate: 0 }}
+                className="relative"
+              >
+                <div
+                  className="relative z-10 border-8 border-black bg-white p-8"
+                  style={{ transform: `rotate(${feature.rotate}deg)` }}
+                >
+                  <div className="mb-6 h-20 w-20 rotate-45 border-8 border-black" style={{ backgroundColor: feature.color }} />
+                  <h3 className="mb-4 text-4xl font-black" style={{ fontFamily: "Impact, sans-serif" }}>
+                    {feature.title}
+                  </h3>
+                  <p className="text-xl font-bold leading-relaxed" style={{ fontFamily: "Arial Black, sans-serif" }}>
+                    {feature.desc}
+                  </p>
+                </div>
+                <div
+                  className="absolute left-4 top-4 z-0 h-full w-full border-8 border-black"
+                  style={{ backgroundColor: feature.color }}
+                />
+              </motion.div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mx-auto mb-20 max-w-7xl">
+          <div className="relative">
+            {[
+              {
+                quote: '"I had points expiring. Now they feed people!"',
+                name: "MAYA",
+                color: "#f7dc6f",
+                rotate: -2,
+                top: 0,
+                left: 0,
+              },
+              {
+                quote: '"No more choosing textbooks over meals!"',
+                name: "JORDAN",
+                color: "#4ecdc4",
+                rotate: 3,
+                top: 120,
+                left: 200,
+              },
+              {
+                quote: '"Most equitable system on campus."',
+                name: "ALEX",
+                color: "#e74c3c",
+                rotate: -1,
+                top: 240,
+                left: 100,
+              },
+            ].map((test, i) => (
+              <motion.div
+                key={`${test.name}-${i}`}
+                initial={{ opacity: 0, scale: 0.8 }}
+                whileInView={{ opacity: 1, scale: 1 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.2 }}
+                whileHover={{ scale: 1.1, rotate: 0, zIndex: 50 }}
+                className="absolute max-w-md border-8 border-black p-8 md:relative"
+                style={{
+                  transform: `rotate(${test.rotate}deg)`,
+                  top: test.top,
+                  left: test.left,
+                  backgroundColor: test.color,
+                  marginBottom: i < 2 ? "80px" : "0",
+                }}
+              >
+                <p className="mb-4 text-2xl font-black" style={{ fontFamily: "Impact, sans-serif" }}>
+                  {test.quote}
+                </p>
+                <p className="text-xl font-bold" style={{ fontFamily: "Arial Black, sans-serif" }}>
+                  {test.name}
+                </p>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mx-auto mb-20 mt-[500px] max-w-5xl text-center md:mt-20">
+          <motion.div initial={{ scale: 0 }} whileInView={{ scale: 1 }} viewport={{ once: true }} className="relative">
+            <div className="relative z-20 border-8 border-[#f7dc6f] bg-black p-16 text-white">
+              <h2 className="mb-8 text-5xl font-black md:text-8xl" style={{ fontFamily: "Impact, sans-serif" }}>
+                OPEN THE
+                <br />
+                WEB APP
+              </h2>
+              <p className="mb-12 text-xl font-bold md:text-2xl" style={{ fontFamily: "Arial Black, sans-serif" }}>
+                EVERY STUDENT DESERVES MEALS
+              </p>
+              <motion.div whileHover={{ scale: 1.15, rotate: 5 }}>
+                <Link
+                  href="/app"
+                  className="inline-flex items-center justify-center border-8 border-black bg-[#e74c3c] px-16 py-10 text-3xl font-black text-black shadow-[12px_12px_0_#f7dc6f]"
+                  style={{ fontFamily: "Impact, sans-serif" }}
+                >
+                  OPEN APP NOW!!!
+                </Link>
+              </motion.div>
+              <Link
+                href="/admin/login"
+                className="mt-6 inline-flex items-center justify-center border-4 border-white px-6 py-3 text-sm font-black tracking-[0.1em] text-white"
+                style={{ fontFamily: "Arial Black, sans-serif" }}
+              >
+                ADMIN LOGIN
+              </Link>
+            </div>
+            <div className="absolute left-8 top-8 z-10 h-full w-full rotate-3 border-8 border-black bg-[#4ecdc4]" />
+            <div className="absolute left-16 top-16 z-0 h-full w-full -rotate-2 border-8 border-black bg-[#f7dc6f]" />
+          </motion.div>
+        </div>
+      </div>
+
+      {FLOATERS.map((item, i) => (
+        <CursorFloater key={`${item.left}-${item.top}`} item={item} i={i} />
+      ))}
+
+      <div className="pointer-events-none absolute bottom-4 right-4 border-4 border-black bg-[#f7dc6f] px-4 py-2 text-xs font-black tracking-[0.1em] text-black md:text-sm" style={{ fontFamily: "Arial Black, sans-serif" }}>
+        LIVE METRICS: {formatCurrency(pointsDistributed)} DISTRIBUTED | {formatCount(activeDonors)} DONORS
+      </div>
+
+      <div className="sr-only">{CHAOS_COLORS.join(",")}</div>
+    </div>
+  );
+}

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -23,8 +23,8 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "SlugSwap Control Deck",
-  description: "Operations dashboard for SlugSwap",
+  title: "SlugSwap",
+  description: "Share dining points with fellow students",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -1,22 +1,28 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
-import DashboardHomePage from "./admin-dashboard-client";
-import { ADMIN_SESSION_COOKIE, verifyAdminSessionToken } from "@/lib/server/admin-auth";
+import LandingClient from "./landing-client";
+import { getAdminConfig } from "@/lib/server/config";
+import { getLandingStats } from "@/lib/server/landing-stats";
 
-export default async function Page() {
-  const cookieStore = await cookies();
-  const sessionToken = cookieStore.get(ADMIN_SESSION_COOKIE)?.value;
-  let isAuthenticated = false;
+export default async function LandingPage() {
+  const stats = await getLandingStats();
+
+  let iosStoreUrl: string | null = null;
+  let androidStoreUrl: string | null = null;
 
   try {
-    isAuthenticated = verifyAdminSessionToken(sessionToken);
-  } catch {
-    isAuthenticated = false;
+    const { config } = await getAdminConfig();
+    iosStoreUrl = config.iosStoreUrl;
+    androidStoreUrl = config.androidStoreUrl;
+  } catch (error) {
+    console.error("Failed to load admin app store config for landing page:", error);
   }
 
-  if (!isAuthenticated) {
-    redirect("/login");
-  }
-
-  return <DashboardHomePage />;
+  return (
+    <LandingClient
+      pointsDistributed={stats.pointsDistributed}
+      activeDonors={stats.activeDonors}
+      asOf={stats.asOf}
+      iosStoreUrl={iosStoreUrl}
+      androidStoreUrl={androidStoreUrl}
+    />
+  );
 }

--- a/apps/dashboard/lib/server/landing-stats.ts
+++ b/apps/dashboard/lib/server/landing-stats.ts
@@ -1,0 +1,49 @@
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/server/db";
+import { claimCodes, donations } from "@/lib/server/schema";
+
+export type LandingStats = {
+  pointsDistributed: number;
+  activeDonors: number;
+  asOf: string;
+};
+
+const FALLBACK_STATS = {
+  pointsDistributed: 497.79,
+  activeDonors: 412,
+} as const;
+
+function toSafeNumber(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed)) return 0;
+  return Math.max(0, parsed);
+}
+
+export async function getLandingStats(): Promise<LandingStats> {
+  const asOf = new Date().toISOString();
+
+  try {
+    const [pointsDistributedResult, activeDonorsResult] = await Promise.all([
+      db
+        .select({ total: sql<number>`coalesce(sum(${claimCodes.amount}), 0)` })
+        .from(claimCodes)
+        .where(eq(claimCodes.status, "redeemed")),
+      db
+        .select({ count: sql<number>`count(distinct ${donations.userId})` })
+        .from(donations)
+        .where(eq(donations.status, "active")),
+    ]);
+
+    return {
+      pointsDistributed: toSafeNumber(pointsDistributedResult[0]?.total),
+      activeDonors: toSafeNumber(activeDonorsResult[0]?.count),
+      asOf,
+    };
+  } catch (error) {
+    console.error("Failed to load landing stats, using fallback values:", error);
+    return {
+      ...FALLBACK_STATS,
+      asOf,
+    };
+  }
+}

--- a/apps/dashboard/next.config.mjs
+++ b/apps/dashboard/next.config.mjs
@@ -4,6 +4,35 @@ const nextConfig = {
   experimental: {
     externalDir: true,
   },
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: "/_expo/:path*",
+          destination: "/app/_expo/:path*",
+        },
+        {
+          source: "/assets/:path*",
+          destination: "/app/assets/:path*",
+        },
+        {
+          source: "/app",
+          destination: "/app/index.html",
+        },
+        {
+          source: "/app/:path*",
+          has: [
+            {
+              type: "header",
+              key: "accept",
+              value: ".*text/html.*",
+            },
+          ],
+          destination: "/app/index.html",
+        },
+      ],
+    };
+  },
 };
 
 export default nextConfig;

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "predev": "npm run build:mobile-web",
     "dev": "next dev",
-    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if [ ! -x ../../node_modules/.bin/expo ]; then npm --prefix ../.. install; fi; if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"PATH=../../node_modules/.bin:\\$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else PATH=../../node_modules/.bin:$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
+    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if [ ! -x ../../node_modules/.bin/expo ]; then npm --prefix ../.. install --include=dev; fi; if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"PATH=../../node_modules/.bin:\\$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else PATH=../../node_modules/.bin:$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
     "build": "npm run build:mobile-web && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "predev": "npm run build:mobile-web",
     "dev": "next dev",
-    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && dotenv -e ../../.env -- sh -c 'EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app'",
+    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
     "build": "npm run build:mobile-web && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -5,18 +5,24 @@
     "@neondatabase/serverless": "^1.0.2",
     "@supabase/supabase-js": "^2.95.3",
     "drizzle-orm": "^0.45.1",
+    "framer-motion": "^12.23.24",
+    "lucide-react": "^0.542.0",
     "next": "^15.5.12",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "tailwindcss": "^4.1.12"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.12",
     "@types/node": "^24.3.0",
     "@types/react": "~19.1.10",
     "typescript": "^5.9.3"
   },
   "scripts": {
+    "predev": "npm run build:mobile-web",
     "dev": "next dev",
-    "build": "next build",
+    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && dotenv -e ../../.env -- sh -c 'EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app'",
+    "build": "npm run build:mobile-web && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"
   }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",
     "@supabase/supabase-js": "^2.95.3",
+    "@tailwindcss/postcss": "^4.1.12",
     "drizzle-orm": "^0.45.1",
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.542.0",
@@ -13,7 +14,6 @@
     "tailwindcss": "^4.1.12"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.12",
     "@types/node": "^24.3.0",
     "@types/react": "~19.1.10",
     "typescript": "^5.9.3"

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "predev": "npm run build:mobile-web",
     "dev": "next dev",
-    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if [ ! -x ../../node_modules/.bin/expo ]; then npm --prefix ../.. install --include=dev; fi; if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"PATH=../../node_modules/.bin:\\$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else PATH=../../node_modules/.bin:$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
+    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if [ ! -x ../../node_modules/.bin/expo ]; then npm --prefix ../.. install --include=dev; fi; rm -rf ../mobile/node_modules; if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"PATH=../../node_modules/.bin:\\$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else PATH=../../node_modules/.bin:$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
     "build": "npm run build:mobile-web && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "predev": "npm run build:mobile-web",
     "dev": "next dev",
-    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if [ ! -x ../mobile/node_modules/.bin/expo ]; then npm --prefix ../mobile install; fi; if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
+    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if [ ! -x ../../node_modules/.bin/expo ]; then npm --prefix ../.. install; fi; if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"PATH=../../node_modules/.bin:\\$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else PATH=../../node_modules/.bin:$PATH EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
     "build": "npm run build:mobile-web && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "predev": "npm run build:mobile-web",
     "dev": "next dev",
-    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
+    "build:mobile-web": "rm -rf public/app && mkdir -p public/app && sh -c 'if [ ! -x ../mobile/node_modules/.bin/expo ]; then npm --prefix ../mobile install; fi; if command -v dotenv >/dev/null 2>&1; then dotenv -e ../../.env -- sh -c \"EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app\"; else EXPO_BASE_URL=app npm --prefix ../mobile run web:build -- --output-dir ../dashboard/public/app; fi'",
     "build": "npm run build:mobile-web && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/apps/dashboard/postcss.config.mjs
+++ b/apps/dashboard/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -1,4 +1,5 @@
 {
   "framework": "nextjs",
+  "buildCommand": "npm run build",
   "outputDirectory": ".next"
 }

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -34,12 +34,17 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
+    "experiments": {
+      "baseUrl": "/app"
+    },
     "scheme": "slugswap",
     "plugins": [
       "expo-router"
     ],
     "extra": {
       "router": {},
+      "supabaseUrl": "https://htaktvkkxeylaelyvxoz.supabase.co",
+      "supabaseAnonKey": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0YWt0dmtreGV5bGFlbHl2eG96Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzA2ODYxMDEsImV4cCI6MjA4NjI2MjEwMX0.0AJ5zxTCC2rYJ9O3Ea-3zvtZmSxL9mO78uPZHf-sMHY",
       "eas": {
         "projectId": "a0a8a9f3-0326-4767-b97d-d610d058d094"
       }

--- a/apps/mobile/app/(tabs)/(request)/index.tsx
+++ b/apps/mobile/app/(tabs)/(request)/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Pressable, ScrollView, ActivityIndicator, Alert, RefreshControl, PlatformColor } from 'react-native';
+import { View, Text, Pressable, ScrollView, ActivityIndicator, Alert, RefreshControl } from 'react-native';
 import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
 import { BlurView } from 'expo-blur';
 import { SymbolView } from 'expo-symbols';
@@ -382,7 +382,7 @@ export default function RequesterScreen() {
               <Text style={{ fontSize: 12, color: uiColor('secondaryLabel') }}>
                 {checkoutDetail}
               </Text>
-              <Text selectable style={{ fontSize: 12, color: PlatformColor('tertiaryLabel') }}>
+              <Text selectable style={{ fontSize: 12, color: uiColor('tertiaryLabel') }}>
                 {donorCourtesyLabel}
               </Text>
             </View>

--- a/apps/mobile/app/(tabs)/(request)/index.tsx
+++ b/apps/mobile/app/(tabs)/(request)/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Pressable, ScrollView, ActivityIndicator, Alert, RefreshControl } from 'react-native';
+import { View, Text, Pressable, ScrollView, ActivityIndicator, Alert, RefreshControl, PlatformColor } from 'react-native';
 import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
 import { BlurView } from 'expo-blur';
 import { SymbolView } from 'expo-symbols';

--- a/apps/mobile/app/(tabs)/(share)/index.tsx
+++ b/apps/mobile/app/(tabs)/(share)/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TextInput, Pressable, ActivityIndicator, Alert, ScrollView, RefreshControl } from 'react-native';
+import { View, Text, TextInput, Pressable, ActivityIndicator, Alert, ScrollView, RefreshControl, Platform } from 'react-native';
 import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
 import { BlurView } from 'expo-blur';
 import { SymbolView } from 'expo-symbols';
@@ -286,29 +286,47 @@ export default function DonorScreen() {
 
   const handleUnlinkGet = () => {
     if (!userId) return;
-    Alert.alert('Unlink GET?', 'Requesters will not be able to generate claim codes until a donor links again.', [
+
+    const runUnlink = async () => {
+      setUnlinkingGet(true);
+      try {
+        await unlinkGetAccount(userId);
+        setIsGetLinked(false);
+        setGetLinkedAt(null);
+        setGetAccounts([]);
+        cacheShareSnapshot({
+          isGetLinked: false,
+          getLinkedAt: null,
+          getAccounts: [],
+        });
+        Alert.alert('Unlinked', 'Your donor GET account has been unlinked.');
+      } catch (error: any) {
+        Alert.alert('Error', error.message || 'Failed to unlink GET account');
+      } finally {
+        setUnlinkingGet(false);
+      }
+    };
+
+    const confirmationMessage =
+      'Requesters will not be able to generate claim codes until a donor links again.';
+
+    if (Platform.OS === 'web') {
+      const confirmed =
+        typeof globalThis.confirm === 'function'
+          ? globalThis.confirm(`Unlink GET?\n\n${confirmationMessage}`)
+          : true;
+      if (!confirmed) return;
+      void runUnlink();
+      return;
+    }
+
+    Alert.alert('Unlink GET?', confirmationMessage, [
       { text: 'Cancel', style: 'cancel' },
       {
         text: 'Unlink',
         style: 'destructive',
-        onPress: async () => {
-          setUnlinkingGet(true);
-          try {
-            await unlinkGetAccount(userId);
-            setIsGetLinked(false);
-            setGetLinkedAt(null);
-            setGetAccounts([]);
-            cacheShareSnapshot({
-              isGetLinked: false,
-              getLinkedAt: null,
-              getAccounts: [],
-            });
-            Alert.alert('Unlinked', 'Your donor GET account has been unlinked.');
-          } catch (error: any) {
-            Alert.alert('Error', error.message || 'Failed to unlink GET account');
-          } finally {
-            setUnlinkingGet(false);
-          }
+        onPress: () => {
+          void runUnlink();
         },
       },
     ]);

--- a/apps/mobile/app/auth/sign-in.tsx
+++ b/apps/mobile/app/auth/sign-in.tsx
@@ -15,7 +15,10 @@ export default function SignIn() {
   const handleGoogleSignIn = async () => {
     setLoading(true);
     try {
-      const redirectUrl = Linking.createURL('auth/callback');
+      const redirectUrl =
+        Platform.OS === 'web' && typeof window !== 'undefined'
+          ? new URL('/app/auth/callback', window.location.origin).toString()
+          : Linking.createURL('auth/callback');
       console.log('Redirect URL:', redirectUrl);
 
       if (Platform.OS === 'web') {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -52,6 +52,9 @@ function resolveApiBaseUrl(): string {
   }
 
   if (Platform.OS === 'web') {
+    if (typeof window !== 'undefined' && window.location?.origin) {
+      return window.location.origin;
+    }
     return FALLBACK_LOCAL_API_URL;
   }
 

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -71,11 +71,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       segments
     });
 
+    const isRootRoute = pathname === '/' && segments.join('/') === '';
+
     // Prevent redirect loops
     if (!session && !inAuthGroup && pathname !== '/auth/sign-in') {
       console.log('Redirecting to sign-in');
       router.replace('/auth/sign-in');
-    } else if (session && (inAuthGroup || pathname === '/')) {
+    } else if (session && (inAuthGroup || isRootRoute)) {
       console.log('Redirecting to share tab');
       router.replace('/(tabs)/(share)');
     }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -2,9 +2,16 @@ import 'react-native-url-polyfill/auto';
 import { createClient } from '@supabase/supabase-js';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
+import Constants from 'expo-constants';
 
-const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+const extra = (Constants.expoConfig?.extra ?? {}) as {
+  supabaseUrl?: string;
+  supabaseAnonKey?: string;
+};
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL ?? extra.supabaseUrl;
+const supabaseAnonKey =
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? extra.supabaseAnonKey;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error(

--- a/lib/tab-cache-context.tsx
+++ b/lib/tab-cache-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState, ReactNode } from 'react';
 import type { DonorImpact } from './api';
 
 export interface GetAccountBalance {
@@ -34,19 +34,41 @@ export function TabCacheProvider({ children }: { children: ReactNode }) {
   const [hasLoadedRequest, setHasLoadedRequest] = useState(false);
   const [shareSnapshot, setShareSnapshotState] = useState<ShareTabSnapshot | null>(null);
 
+  const markShareLoaded = useCallback(() => {
+    setHasLoadedShare(true);
+  }, []);
+
+  const markRequestLoaded = useCallback(() => {
+    setHasLoadedRequest(true);
+  }, []);
+
+  const setShareSnapshot = useCallback((snapshot: ShareTabSnapshot) => {
+    setShareSnapshotState(snapshot);
+    setHasLoadedShare(true);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      hasLoadedShare,
+      hasLoadedRequest,
+      shareSnapshot,
+      markShareLoaded,
+      markRequestLoaded,
+      setShareSnapshot,
+    }),
+    [
+      hasLoadedShare,
+      hasLoadedRequest,
+      shareSnapshot,
+      markShareLoaded,
+      markRequestLoaded,
+      setShareSnapshot,
+    ]
+  );
+
   return (
     <TabCacheContext.Provider
-      value={{
-        hasLoadedShare,
-        hasLoadedRequest,
-        shareSnapshot,
-        markShareLoaded: () => setHasLoadedShare(true),
-        markRequestLoaded: () => setHasLoadedRequest(true),
-        setShareSnapshot: (snapshot) => {
-          setShareSnapshotState(snapshot);
-          setHasLoadedShare(true);
-        },
-      }}
+      value={value}
     >
       {children}
     </TabCacheContext.Provider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "drizzle-orm": "^0.45.1",
         "expo": "~54.0.33",
         "next": "^15.5.6",
+        "playwright": "^1.58.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -44,11 +45,15 @@
         "@neondatabase/serverless": "^1.0.2",
         "@supabase/supabase-js": "^2.95.3",
         "drizzle-orm": "^0.45.1",
+        "framer-motion": "^12.23.24",
+        "lucide-react": "^0.542.0",
         "next": "^15.5.12",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.1.12",
         "@types/node": "^24.3.0",
         "@types/react": "~19.1.10",
         "typescript": "^5.9.3"
@@ -102,6 +107,19 @@
         "graphql": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7780,6 +7798,306 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
+      "integrity": "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.31.1",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.1.tgz",
+      "integrity": "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.1",
+        "@tailwindcss/oxide-darwin-x64": "4.2.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz",
+      "integrity": "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz",
+      "integrity": "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz",
+      "integrity": "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz",
+      "integrity": "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz",
+      "integrity": "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz",
+      "integrity": "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz",
+      "integrity": "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz",
+      "integrity": "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz",
+      "integrity": "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz",
+      "integrity": "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
+      "integrity": "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz",
+      "integrity": "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.1.tgz",
+      "integrity": "sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.1",
+        "@tailwindcss/oxide": "4.2.1",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -12841,6 +13159,20 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -14383,6 +14715,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.34.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.4.tgz",
+      "integrity": "sha512-q1PwNhc1XJ3qYG7nc9+pEU5P3tnjB6Eh9vv5gGzy61nedDLB4+xk5peMCWhKM0Zn6sfhgunf/q9n0UgCoyKOBA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.3",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/freeport-async": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz",
@@ -15704,6 +16063,16 @@
       "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==",
       "license": "MIT"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jks-js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jks-js/-/jks-js-1.1.0.tgz",
@@ -16287,6 +16656,25 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.542.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
+      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-error": {
@@ -16984,6 +17372,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
+      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -17902,6 +18305,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {
@@ -19882,6 +20329,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       "dependencies": {
         "@neondatabase/serverless": "^1.0.2",
         "@supabase/supabase-js": "^2.95.3",
+        "@tailwindcss/postcss": "^4.1.12",
         "drizzle-orm": "^0.45.1",
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.542.0",
@@ -53,7 +54,6 @@
         "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4.1.12",
         "@types/node": "^24.3.0",
         "@types/react": "~19.1.10",
         "typescript": "^5.9.3"
@@ -113,7 +113,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7802,7 +7801,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
       "integrity": "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -7818,7 +7816,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.1.tgz",
       "integrity": "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -7845,7 +7842,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7862,7 +7858,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7879,7 +7874,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7896,7 +7890,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7913,7 +7906,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7930,7 +7922,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7947,7 +7938,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7964,7 +7954,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7981,7 +7970,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8006,7 +7994,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8028,7 +8015,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8045,7 +8031,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8059,7 +8044,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.1.tgz",
       "integrity": "sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -8073,7 +8057,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -13163,7 +13146,6 @@
       "version": "5.20.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
       "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -16067,7 +16049,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -16671,7 +16652,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -20341,7 +20321,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -48,12 +48,13 @@
     "@supabase/supabase-js": "^2.95.3",
     "better-auth": "^1.4.18",
     "drizzle-orm": "^0.45.1",
+    "expo": "~54.0.33",
     "next": "^15.5.6",
+    "playwright": "^1.58.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "vercel": "^50.14.0",
-    "expo": "~54.0.33",
-    "react-native": "0.81.5"
+    "react-native": "0.81.5",
+    "vercel": "^50.14.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Summary
- move admin routes to `/admin` and `/admin/login`
- make `/` a maximalist chaos landing with live metrics
- add server landing stats (`pointsDistributed`, `activeDonors`) with fallback safety
- wire landing CTAs to `/app`, iOS, and Android store config
- export Expo web into `apps/dashboard/public/app` and serve via Next rewrites under `/app`
- keep same-origin API behavior for web mobile app
- add Tailwind postcss config and dashboard build wiring for composed Next + Expo export
- add OAuth fallback handoff from landing (`/`) to `/app/auth/callback` when auth payload is present

## Validation
- `npm run dashboard:typecheck`
- `npm run mobile:typecheck`
- `npm run build:mobile-web -w @slugswap/dashboard`
