### PR TITLE
Show donor GET balance on dashboard

### DIFF
--- a/apps/dashboard/app/admin-dashboard-client.tsx
+++ b/apps/dashboard/app/admin-dashboard-client.tsx
@@ -111,6 +111,8 @@ type AdminStatsResponse = {
     email: string | null;
     amount: number;
     status: string;
+    hasLinkedGet: boolean;
+    trackedGetBalanceTotal: number | null;
     capAmount: number;
     redeemedThisWeek: number;
     reservedThisWeek: number;
@@ -2059,6 +2061,11 @@ export default function DashboardHomePage() {
                         )
                           ? donor.status
                           : "active";
+                        const donorGetBalanceLabel = !donor.hasLinkedGet
+                          ? "GET not linked"
+                          : donor.trackedGetBalanceTotal === null
+                            ? "GET unavailable"
+                            : `GET ${formatNum(donor.trackedGetBalanceTotal)} pts`;
 
                         return (
                           <div className="donor-row" key={`${donor.userId}-${index}`}>
@@ -2069,6 +2076,7 @@ export default function DashboardHomePage() {
                               <div className="donor-email">
                                 {donor.email ? donor.email.split("@")[0] : "—"}
                               </div>
+                              <div className="donor-balance">{donorGetBalanceLabel}</div>
                               <div className="donor-email">
                                 Cap {formatNum(donor.capAmount)} · Redeemed {formatNum(donor.redeemedThisWeek)} · Reserved {formatNum(donor.reservedThisWeek)} · Remaining {formatNum(donor.remainingThisWeek)} · {donor.capReached ? "Cap reached" : "Within cap"}
                               </div>

--- a/apps/dashboard/app/api/admin/[action]/route.ts
+++ b/apps/dashboard/app/api/admin/[action]/route.ts
@@ -45,6 +45,44 @@ function getWeekBounds() {
   return { weekStart, weekEnd };
 }
 
+const TRACKED_GET_ACCOUNT_NAMES = new Set([
+  "flexi dollars",
+  "banana bucks",
+  "slug points",
+]);
+
+function getTrackedGetBalanceTotal(
+  accounts: Array<{ accountDisplayName: string; balance: number | null }>
+): number | null {
+  let total = 0;
+  let foundTrackedBalance = false;
+
+  for (const account of accounts) {
+    if (!TRACKED_GET_ACCOUNT_NAMES.has(account.accountDisplayName.trim().toLowerCase())) {
+      continue;
+    }
+    if (typeof account.balance !== "number" || Number.isNaN(account.balance)) {
+      continue;
+    }
+
+    total += account.balance;
+    foundTrackedBalance = true;
+  }
+
+  return foundTrackedBalance ? total : null;
+}
+
+async function fetchTrackedGetBalanceTotal(userId: string): Promise<number | null> {
+  try {
+    const { sessionId } = await getActiveGetSession(userId);
+    const accounts = await retrieveAccounts(sessionId);
+    return getTrackedGetBalanceTotal(accounts);
+  } catch (error) {
+    console.warn(`Failed to fetch live GET balance for donor ${userId}:`, error);
+    return null;
+  }
+}
+
 async function getActiveWeeklyPool() {
   const pools = await db
     .select()
@@ -437,9 +475,11 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
           status: schema.donations.status,
           userName: schema.users.name,
           userEmail: schema.users.email,
+          linkedGetUserId: schema.getCredentials.userId,
         })
         .from(schema.donations)
         .leftJoin(schema.users, eq(schema.donations.userId, schema.users.id))
+        .leftJoin(schema.getCredentials, eq(schema.donations.userId, schema.getCredentials.userId))
         .orderBy(desc(schema.donations.amount))
         .limit(10);
 
@@ -598,6 +638,16 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
         .select({ count: sqlOp<number>`count(*)` })
         .from(schema.getCredentials);
 
+      const topDonorsWithGetBalance = await Promise.all(
+        topDonors.map(async (donor) => ({
+          ...donor,
+          hasLinkedGet: Boolean(donor.linkedGetUserId),
+          trackedGetBalanceTotal: donor.linkedGetUserId
+            ? await fetchTrackedGetBalanceTotal(donor.userId)
+            : null,
+        }))
+      );
+
       return NextResponse.json(
         {
           timestamp: new Date().toISOString(),
@@ -649,7 +699,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
             createdAt: c.createdAt.toISOString(),
             expiresAt: c.expiresAt.toISOString(),
           })),
-          topDonors: topDonors.map((d) => {
+          topDonors: topDonorsWithGetBalance.map((d) => {
             const fallbackCap = parseFloat(d.amount);
             const usage = usageMap.get(d.userId);
             return {
@@ -658,6 +708,8 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
               email: d.userEmail,
               amount: parseFloat(d.amount),
               status: d.status,
+              hasLinkedGet: d.hasLinkedGet,
+              trackedGetBalanceTotal: d.trackedGetBalanceTotal,
               capAmount: usage?.capAmount ?? fallbackCap,
               redeemedThisWeek: usage?.redeemedThisWeek ?? 0,
               reservedThisWeek: usage?.reservedThisWeek ?? 0,
@@ -756,12 +808,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
         }
       }
 
-      const trackedAccountNames = new Set(["flexi dollars", "banana bucks", "slug points"]);
-      const trackedGetBalanceTotal = (getBalance ?? []).reduce((sum, account) => {
-        if (!trackedAccountNames.has(account.accountDisplayName.trim().toLowerCase())) return sum;
-        if (typeof account.balance !== "number" || Number.isNaN(account.balance)) return sum;
-        return sum + account.balance;
-      }, 0);
+      const trackedGetBalanceTotal = getTrackedGetBalanceTotal(getBalance ?? []) ?? 0;
 
       // Weekly allowance
       const currentPool = await db

--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -1091,6 +1091,13 @@ body {
   font-weight: 300;
 }
 
+.admin-root .donor-balance {
+  font-size: 0.7rem;
+  color: color-mix(in srgb, var(--accent-gold) 78%, white 22%);
+  font-family: var(--font-mono);
+  font-weight: 400;
+}
+
 .admin-root .donor-amount {
   font-family: var(--font-mono);
   font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- add live tracked GET balance data to the admin stats response for top donors
- show each donor's GET balance in the Top Donors dashboard card
- keep linked, unavailable, and unlinked GET states explicit in the UI

## Testing
- npm run dashboard:typecheck