### PR TITLE
Auto-pause donors with depleted GET balances

### DIFF
--- a/apps/dashboard/app/api/admin/[action]/route.ts
+++ b/apps/dashboard/app/api/admin/[action]/route.ts
@@ -21,7 +21,11 @@ import {
 import { getDonorWeeklyUsageMap } from "@/lib/server/claims/donor-usage";
 import { getPacificWeekWindow } from "@/lib/server/timezone";
 import { getActiveGetSession } from "@/lib/server/get/session";
-import { retrieveAccounts } from "@/lib/server/get/tools";
+import { retrieveAccounts, type GetAccount } from "@/lib/server/get/tools";
+import {
+  getTrackedBalanceTotal,
+  syncDonorPauseStateFromAccounts,
+} from "@/lib/server/get/tracked-balance";
 import {
   authenticateAdminBearerToken,
   clearAdminSessionCookie,
@@ -743,12 +747,13 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
         where: eq(schema.getCredentials.userId, user.id),
       });
 
-      let getBalance: Array<{ id: string; accountDisplayName: string; balance: number | null }> | null = null;
+      let getBalance: GetAccount[] | null = null;
       let getAccountsError: string | null = null;
       if (getCredential) {
         try {
           const { sessionId } = await getActiveGetSession(user.id);
           getBalance = await retrieveAccounts(sessionId);
+          await syncDonorPauseStateFromAccounts(user.id, getBalance);
         } catch (error: any) {
           getAccountsError = error?.message || "Failed to fetch GET balances";
           console.warn("Failed to fetch GET balance:", error);
@@ -756,12 +761,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
         }
       }
 
-      const trackedAccountNames = new Set(["flexi dollars", "banana bucks", "slug points"]);
-      const trackedGetBalanceTotal = (getBalance ?? []).reduce((sum, account) => {
-        if (!trackedAccountNames.has(account.accountDisplayName.trim().toLowerCase())) return sum;
-        if (typeof account.balance !== "number" || Number.isNaN(account.balance)) return sum;
-        return sum + account.balance;
-      }, 0);
+      const trackedGetBalanceTotal = getTrackedBalanceTotal(getBalance ?? []) ?? 0;
 
       // Weekly allowance
       const currentPool = await db

--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/server/claims/donor-selection";
 import { retrieveAccounts, type GetAccount } from "@/lib/server/get/tools";
 import { getActiveGetSession } from "@/lib/server/get/session";
+import { syncDonorPauseStateFromAccounts } from "@/lib/server/get/tracked-balance";
 
 export const runtime = "nodejs";
 
@@ -212,6 +213,7 @@ async function handleGenerate(req: NextRequest) {
 
     const ranked = await rankDonorCandidatesForClaim(claimAmount);
     let hadCapReject = false;
+    let hadDepletedBalanceReject = false;
     const fetchFailures: string[] = [];
 
     for (const candidate of ranked.candidates) {
@@ -229,19 +231,27 @@ async function handleGenerate(req: NextRequest) {
       }
 
       try {
-        const { code, expiresAt, sessionId: donorSessionId } =
-          await fetchLiveClaimCodeFromGet(candidate.donorUserId);
+        const { sessionId: donorSessionId } = await getActiveGetSession(
+          candidate.donorUserId
+        );
+        const accounts = await retrieveAccounts(donorSessionId);
+        const { trackedBalance } = await syncDonorPauseStateFromAccounts(
+          candidate.donorUserId,
+          accounts
+        );
 
-        let balanceSnapshot: string | null = null;
-        let recommendedRail: CheckoutRail = "points-or-bucks";
-        try {
-          const accounts = await retrieveAccounts(donorSessionId);
-          const snapshot = toTrackedBalanceSnapshot(accounts);
-          balanceSnapshot = JSON.stringify(snapshot);
-          recommendedRail = chooseCheckoutRail(snapshot, claimAmount);
-        } catch (error) {
-          console.warn("Failed to snapshot donor balances:", error);
+        if (trackedBalance != null && trackedBalance <= 0) {
+          hadDepletedBalanceReject = true;
+          continue;
         }
+
+        const snapshot = toTrackedBalanceSnapshot(accounts);
+        const balanceSnapshot = JSON.stringify(snapshot);
+        const recommendedRail = chooseCheckoutRail(snapshot, claimAmount);
+        const { code, expiresAt } = await fetchLiveClaimCodeFromGet(
+          candidate.donorUserId,
+          donorSessionId
+        );
 
         const [claimCode] = await db
           .insert(schema.claimCodes)
@@ -287,7 +297,7 @@ async function handleGenerate(req: NextRequest) {
       }
     }
 
-    if (hadCapReject && fetchFailures.length === 0) {
+    if ((hadCapReject || hadDepletedBalanceReject) && fetchFailures.length === 0) {
       return claimGenerationErrorResponse(
         POOL_EXHAUSTED_MESSAGE,
         409,
@@ -510,6 +520,7 @@ async function detectRedemption(
   try {
     const { sessionId } = await getActiveGetSession(claim.donorUserId);
     currentAccounts = await retrieveAccounts(sessionId);
+    await syncDonorPauseStateFromAccounts(claim.donorUserId, currentAccounts);
   } catch (error) {
     console.warn("Failed to poll donor balances for redemption check:", error);
     return null;

--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -17,9 +17,60 @@ export const runtime = "nodejs";
 type Ctx = { params: Promise<{ action: string }> };
 type CheckoutRail = "points-or-bucks" | "flexi-dollars";
 type BalanceSnapshotEntry = { id: string; name: string; balance: number | null };
+type ClaimGenerationFailureReason =
+  | "allowance_exhausted"
+  | "pool_exhausted"
+  | "pool_unavailable";
 
 const FLEXI_ACCOUNT_NAME = "flexi dollars";
 const POINTS_OR_BUCKS_ACCOUNT_NAMES = new Set(["banana bucks", "slug points"]);
+const POOL_EXHAUSTED_MESSAGE =
+  "Your personal allowance is still there, but the shared pool is empty. Check back later.";
+const POOL_UNAVAILABLE_MESSAGE =
+  "Points are temporarily unavailable right now. Please try again in a moment.";
+
+function claimGenerationErrorResponse(
+  error: string,
+  status: number,
+  reason?: ClaimGenerationFailureReason,
+  extra?: Record<string, unknown>
+) {
+  return NextResponse.json(
+    {
+      error,
+      ...(reason ? { reason } : {}),
+      ...(extra ?? {}),
+    },
+    { status }
+  );
+}
+
+function classifyClaimGenerationError(message: string): {
+  error: string;
+  reason?: ClaimGenerationFailureReason;
+  status: number;
+} {
+  if (message.includes("No eligible donors available under weekly cap limits")) {
+    return {
+      error: POOL_EXHAUSTED_MESSAGE,
+      reason: "pool_exhausted",
+      status: 409,
+    };
+  }
+
+  if (message.includes("No linked donor GET account available")) {
+    return {
+      error: POOL_UNAVAILABLE_MESSAGE,
+      reason: "pool_unavailable",
+      status: 503,
+    };
+  }
+
+  return {
+    error: message || "Internal server error",
+    status: 500,
+  };
+}
 
 function toTrackedBalanceSnapshot(accounts: GetAccount[]): BalanceSnapshotEntry[] {
   return accounts.map((account) => ({
@@ -151,9 +202,11 @@ async function handleGenerate(req: NextRequest) {
     const allowance = userAllowance[0];
     const remaining = parseFloat(allowance.remainingAmount);
     if (claimAmount > remaining) {
-      return NextResponse.json(
-        { error: "Insufficient allowance", remaining },
-        { status: 400 }
+      return claimGenerationErrorResponse(
+        "Insufficient allowance",
+        400,
+        "allowance_exhausted",
+        { remaining }
       );
     }
 
@@ -235,33 +288,29 @@ async function handleGenerate(req: NextRequest) {
     }
 
     if (hadCapReject && fetchFailures.length === 0) {
-      return NextResponse.json(
-        { error: "No eligible donors available under weekly cap limits." },
-        { status: 400 }
+      return claimGenerationErrorResponse(
+        POOL_EXHAUSTED_MESSAGE,
+        409,
+        "pool_exhausted"
       );
     }
 
-    return NextResponse.json(
-      {
-        error:
-          fetchFailures.length > 0
-            ? `All donor barcode attempts failed: ${fetchFailures[0]}`
-            : "No eligible donors available.",
-      },
-      { status: 500 }
+    return claimGenerationErrorResponse(
+      POOL_UNAVAILABLE_MESSAGE,
+      503,
+      "pool_unavailable",
+      fetchFailures.length > 0
+        ? { upstreamError: `All donor barcode attempts failed: ${fetchFailures[0]}` }
+        : undefined
     );
   } catch (error: any) {
     console.error("Error generating claim code:", error);
     const message = error?.message || "Internal server error";
-    const status =
-      typeof message === "string" &&
-      (message.includes("No eligible donors available") ||
-        message.includes("No linked donor GET account available"))
-        ? 400
-        : 500;
-    return NextResponse.json(
-      { error: message },
-      { status }
+    const classified = classifyClaimGenerationError(message);
+    return claimGenerationErrorResponse(
+      classified.error,
+      classified.status,
+      classified.reason
     );
   }
 }

--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -61,9 +61,9 @@ function classifyClaimGenerationError(message: string): {
 
   if (message.includes("No linked donor GET account available")) {
     return {
-      error: POOL_UNAVAILABLE_MESSAGE,
-      reason: "pool_unavailable",
-      status: 503,
+      error: POOL_EXHAUSTED_MESSAGE,
+      reason: "pool_exhausted",
+      status: 409,
     };
   }
 

--- a/apps/dashboard/app/api/get/[action]/route.ts
+++ b/apps/dashboard/app/api/get/[action]/route.ts
@@ -14,6 +14,7 @@ import {
   verifyPin,
 } from "@/lib/server/get/tools";
 import { getActiveGetSession } from "@/lib/server/get/session";
+import { syncDonorPauseStateFromAccounts } from "@/lib/server/get/tracked-balance";
 
 export const runtime = "nodejs";
 
@@ -148,6 +149,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
 
       const { sessionId } = await getActiveGetSession(userId);
       const accounts = await retrieveAccounts(sessionId);
+      await syncDonorPauseStateFromAccounts(userId, accounts);
 
       return NextResponse.json(
         { linked: true, accounts },

--- a/apps/dashboard/lib/server/claims/donor-selection.ts
+++ b/apps/dashboard/lib/server/claims/donor-selection.ts
@@ -6,15 +6,13 @@ import {
   type DonorWeeklyUsage,
 } from "@/lib/server/claims/donor-usage";
 import { getActiveGetSession } from "@/lib/server/get/session";
-import { retrieveAccounts, type GetAccount } from "@/lib/server/get/tools";
+import { retrieveAccounts } from "@/lib/server/get/tools";
+import {
+  getTrackedBalanceTotal,
+  syncDonorPauseStateFromAccounts,
+} from "@/lib/server/get/tracked-balance";
 import { getAdminConfig, type DonorSelectionPolicy } from "@/lib/server/config";
 import { type WeekWindow } from "@/lib/server/timezone";
-
-const TRACKED_BALANCE_ACCOUNT_NAMES = new Set([
-  "flexi dollars",
-  "banana bucks",
-  "slug points",
-]);
 
 export type RankedDonorCandidate = {
   donorUserId: string;
@@ -34,27 +32,12 @@ function parsePoints(value: string | number): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function trackedBalanceTotal(accounts: GetAccount[]): number | null {
-  const tracked = accounts.filter((account) =>
-    TRACKED_BALANCE_ACCOUNT_NAMES.has(account.accountDisplayName.trim().toLowerCase())
-  );
-
-  let total = 0;
-  let found = false;
-  for (const account of tracked) {
-    if (typeof account.balance !== "number" || Number.isNaN(account.balance)) continue;
-    total += account.balance;
-    found = true;
-  }
-
-  return found ? total : null;
-}
-
 async function fetchLiveTrackedBalance(donorUserId: string): Promise<number | null> {
   try {
     const { sessionId } = await getActiveGetSession(donorUserId);
     const accounts = await retrieveAccounts(sessionId);
-    return trackedBalanceTotal(accounts);
+    const { trackedBalance } = await syncDonorPauseStateFromAccounts(donorUserId, accounts);
+    return trackedBalance ?? getTrackedBalanceTotal(accounts);
   } catch (error) {
     console.warn(`Failed to retrieve live balance for donor ${donorUserId}:`, error);
     return null;
@@ -157,7 +140,15 @@ export async function rankDonorCandidatesForClaim(
       (candidate) => typeof candidate.liveTrackedBalance === "number"
     );
 
-    candidates = withBalances;
+    candidates = withBalances.filter(
+      (candidate) =>
+        candidate.liveTrackedBalance == null || candidate.liveTrackedBalance > 0
+    );
+
+    if (candidates.length === 0) {
+      throw new Error("No eligible donors available under weekly cap limits.");
+    }
+
     if (hasLiveBalance) {
       candidates.sort(highestBalanceSort);
     } else {

--- a/apps/dashboard/lib/server/claims/get-claim-code.ts
+++ b/apps/dashboard/lib/server/claims/get-claim-code.ts
@@ -14,9 +14,12 @@ function extractBarcodePayload(raw: unknown): string | null {
 }
 
 export async function fetchLiveClaimCodeFromGet(
-  userId: string
+  userId: string,
+  existingSessionId?: string
 ): Promise<{ code: string; expiresAt: Date; sessionId: string }> {
-  const { sessionId } = await getActiveGetSession(userId);
+  const { sessionId } = existingSessionId
+    ? { sessionId: existingSessionId }
+    : await getActiveGetSession(userId);
   const payload = await callGetApi<{ sessionId: string }, unknown>(
     "authentication",
     "retrievePatronBarcodePayload",

--- a/apps/dashboard/lib/server/get/tracked-balance.ts
+++ b/apps/dashboard/lib/server/get/tracked-balance.ts
@@ -1,0 +1,50 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/server/db";
+import { donations } from "@/lib/server/schema";
+import { type GetAccount } from "@/lib/server/get/tools";
+
+export const TRACKED_BALANCE_ACCOUNT_NAMES = new Set([
+  "flexi dollars",
+  "banana bucks",
+  "slug points",
+]);
+
+export function getTrackedBalanceTotal(accounts: GetAccount[]): number | null {
+  const tracked = accounts.filter((account) =>
+    TRACKED_BALANCE_ACCOUNT_NAMES.has(account.accountDisplayName.trim().toLowerCase())
+  );
+
+  let total = 0;
+  let found = false;
+  for (const account of tracked) {
+    if (typeof account.balance !== "number" || Number.isNaN(account.balance)) continue;
+    total += account.balance;
+    found = true;
+  }
+
+  return found ? total : null;
+}
+
+export async function syncDonorPauseStateFromAccounts(
+  donorUserId: string,
+  accounts: GetAccount[]
+): Promise<{ trackedBalance: number | null; autoPaused: boolean }> {
+  const trackedBalance = getTrackedBalanceTotal(accounts);
+  if (trackedBalance == null || trackedBalance > 0) {
+    return { trackedBalance, autoPaused: false };
+  }
+
+  const [updated] = await db
+    .update(donations)
+    .set({
+      status: "paused",
+      updatedAt: new Date(),
+    })
+    .where(and(eq(donations.userId, donorUserId), eq(donations.status, "active")))
+    .returning({ userId: donations.userId });
+
+  return {
+    trackedBalance,
+    autoPaused: !!updated,
+  };
+}

--- a/apps/mobile/app/(tabs)/(request)/index.tsx
+++ b/apps/mobile/app/(tabs)/(request)/index.tsx
@@ -4,7 +4,15 @@ import { BlurView } from 'expo-blur';
 import { SymbolView } from 'expo-symbols';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { supabase } from '../../../../../lib/supabase';
-import { getRequesterAllowance, generateClaimCode, getClaimHistory, refreshClaimCode, checkRedemption, type CheckoutRail } from '../../../../../lib/api';
+import {
+  getRequesterAllowance,
+  generateClaimCode,
+  getClaimHistory,
+  refreshClaimCode,
+  checkRedemption,
+  type CheckoutRail,
+  type ClaimGenerationFailureReason,
+} from '../../../../../lib/api';
 import { PDF417Barcode } from '../../../components/PDF417Barcode';
 import { useTabCache } from '../../../../../lib/tab-cache-context';
 import { uiColor } from '../../../lib/ui-color';
@@ -23,6 +31,35 @@ interface ClaimCode {
 
 const FLEXI_ACCOUNT_NAME = 'flexi dollars';
 const POINTS_OR_BUCKS_ACCOUNT_NAMES = new Set(['banana bucks', 'slug points']);
+const DEFAULT_CLAIM_AMOUNT = 10;
+const POOL_EXHAUSTED_TITLE = "We're all out of points right now";
+const POOL_EXHAUSTED_MESSAGE =
+  'Your personal allowance is still there, but the shared pool is empty. Check back later.';
+const LEGACY_POOL_EXHAUSTED_MESSAGES = [
+  'No eligible donors available under weekly cap limits.',
+  'No eligible donors available.',
+];
+
+function getClaimFailureReason(error: unknown): ClaimGenerationFailureReason | null {
+  if (!error || typeof error !== 'object') return null;
+
+  if ('reason' in error) {
+    const reason = (error as { reason?: unknown }).reason;
+    if (typeof reason === 'string') {
+      return reason as ClaimGenerationFailureReason;
+    }
+  }
+
+  const message = 'message' in error ? (error as { message?: unknown }).message : undefined;
+  if (
+    typeof message === 'string' &&
+    LEGACY_POOL_EXHAUSTED_MESSAGES.some((legacyMessage) => message.includes(legacyMessage))
+  ) {
+    return 'pool_exhausted';
+  }
+
+  return null;
+}
 
 function inferCheckoutRail(accountName?: string): CheckoutRail | null {
   if (!accountName) return null;
@@ -74,6 +111,7 @@ export default function RequesterScreen() {
     amount: number;
     accountName?: string;
   } | null>(null);
+  const [poolExhaustedMessage, setPoolExhaustedMessage] = useState<string | null>(null);
   const redeemedRail = inferCheckoutRail(redemptionInfo?.accountName);
   const activeCheckoutRail: CheckoutRail = currentCode?.recommendedRail ?? 'points-or-bucks';
   const checkoutInstruction =
@@ -186,6 +224,9 @@ export default function RequesterScreen() {
       setWeeklyAllowance(allowanceData.weeklyLimit);
       setRemainingAllowance(allowanceData.remainingAmount);
       setDaysUntilReset(allowanceData.daysUntilReset);
+      if (allowanceData.remainingAmount < DEFAULT_CLAIM_AMOUNT) {
+        setPoolExhaustedMessage(null);
+      }
 
       const historyData = await getClaimHistory(user.id);
       setClaimHistory(historyData.claims);
@@ -208,9 +249,8 @@ export default function RequesterScreen() {
   const handleGenerateCode = async () => {
     if (!userId) return;
 
-    const DEFAULT_CLAIM_AMOUNT = 10;
-
     if (remainingAllowance < DEFAULT_CLAIM_AMOUNT) {
+      setPoolExhaustedMessage(null);
       Alert.alert('Insufficient Allowance', `You need at least ${DEFAULT_CLAIM_AMOUNT} points remaining`);
       return;
     }
@@ -218,6 +258,7 @@ export default function RequesterScreen() {
     setGenerating(true);
     try {
       const result = await generateClaimCode(userId, DEFAULT_CLAIM_AMOUNT);
+      setPoolExhaustedMessage(null);
       setCurrentCode({
         ...result.claimCode,
         recommendedRail: result.claimCode.recommendedRail ?? 'points-or-bucks',
@@ -225,7 +266,14 @@ export default function RequesterScreen() {
       });
       await loadUserAndAllowance();
     } catch (error: any) {
+      const reason = getClaimFailureReason(error);
+      if (reason === 'pool_exhausted') {
+        console.log('Claim generation blocked: shared pool exhausted.');
+        setPoolExhaustedMessage(POOL_EXHAUSTED_MESSAGE);
+        return;
+      }
       console.error('Error generating code:', error);
+      setPoolExhaustedMessage(null);
       Alert.alert('Error', error.message || 'Failed to generate claim code');
     } finally {
       setGenerating(false);
@@ -398,6 +446,37 @@ export default function RequesterScreen() {
             <Text style={{ marginTop: 8, textAlign: 'center', fontSize: 12, color: uiColor('tertiaryLabel') }}>
               Refreshing every 5s{refreshingCode ? ' ...' : ''}
             </Text>
+          </Card>
+        ) : !redemptionInfo && poolExhaustedMessage && remainingAllowance >= DEFAULT_CLAIM_AMOUNT ? (
+          <Card>
+            <View style={{ alignItems: 'center', gap: 12 }}>
+              <SymbolView name="exclamationmark.circle.fill" tintColor={uiColor('systemOrange')} size={40} />
+              <Text style={{ fontSize: 22, fontWeight: '700', color: uiColor('label'), textAlign: 'center' }}>
+                {POOL_EXHAUSTED_TITLE}
+              </Text>
+              <Text style={{ fontSize: 15, color: uiColor('secondaryLabel'), textAlign: 'center', lineHeight: 22 }}>
+                {poolExhaustedMessage}
+              </Text>
+              <Pressable
+                onPress={handleGenerateCode}
+                disabled={generating}
+                style={({ pressed }) => ({
+                  marginTop: 4,
+                  paddingVertical: 12,
+                  paddingHorizontal: 24,
+                  borderRadius: 10,
+                  borderCurve: 'continuous',
+                  backgroundColor: uiColor('systemBlue'),
+                  opacity: pressed || generating ? 0.7 : 1,
+                })}
+              >
+                {generating ? (
+                  <ActivityIndicator color="#fff" />
+                ) : (
+                  <Text style={{ color: '#fff', fontSize: 15, fontWeight: '600' }}>Try Again</Text>
+                )}
+              </Pressable>
+            </View>
           </Card>
         ) : !redemptionInfo ? (
           <Pressable

--- a/docs/pooled-weekly-model-spec.md
+++ b/docs/pooled-weekly-model-spec.md
@@ -1,0 +1,126 @@
+# SlugSwap Pooled Weekly Model Spec
+
+This document is the source of truth for how SlugSwap behaves when requesters draw from a shared weekly pool.
+
+## Product Rules
+
+1. Donors contribute to a shared weekly pool.
+2. Requesters have an individual weekly allowance.
+3. A requester can only generate a claim when both conditions are true:
+   - They have enough personal allowance left for the claim amount.
+   - The shared pool can still support a new claim.
+4. Existing active claim codes stay usable until they expire, even if the pool becomes empty right after generation.
+
+## Capacity States
+
+SlugSwap should distinguish these states instead of showing a generic failure:
+
+### 1. `allowance_available`
+
+- The requester has enough weekly allowance remaining.
+- The shared pool can support another claim.
+- The primary CTA is enabled.
+
+### 2. `allowance_exhausted`
+
+- The requester does not have enough allowance left for the minimum claim amount.
+- The primary CTA is disabled.
+- This is a personal limit, not a community shortage.
+
+Requester copy:
+- Title: `You’re out of points for this week`
+- Body: `You’ve used your SlugSwap allowance. Your allowance resets next week.`
+
+### 3. `pool_low`
+
+- The requester still has allowance, but the shared pool is getting tight.
+- Claiming is still allowed.
+- A warning should appear before the pool is fully exhausted.
+
+Requester copy:
+- Title: `Points are running low`
+- Body: `You can still claim right now, but shared points may run out soon.`
+
+### 4. `pool_exhausted`
+
+- The requester still has allowance, but no new claim can be issued because the community pool cannot support another claim.
+- The primary CTA is disabled or replaced with a retry action.
+- This state should be shown inline on the requester screen, not only as an alert.
+- The message should explicitly tell the user that SlugSwap is out of shared points right now.
+
+Requester copy:
+- Title: `We’re all out of points right now`
+- Body: `Your personal allowance is still there, but the shared pool is empty. Check back later.`
+
+### 5. `pool_unavailable`
+
+- The system cannot determine usable capacity because donor access or GET Tools is temporarily unavailable.
+- This is not the same as being out of points.
+- The requester should see a temporary-unavailability message, not an exhausted-pool message.
+
+Requester copy:
+- Title: `Points are temporarily unavailable`
+- Body: `SlugSwap couldn’t generate a claim right now. Please try again in a moment.`
+
+## Requester Experience When The Pool Is Exhausted
+
+When the app is out of shared points, the requester experience should behave like this:
+
+1. Keep showing the requester's remaining weekly allowance.
+2. Replace the normal generate-claim CTA with an exhausted-state card or a disabled button.
+3. Explain that the block is caused by the shared pool, not by the requester doing anything wrong.
+4. Continue showing the weekly reset timing.
+5. Keep claim history visible.
+6. Preserve any already-generated active claim code until it expires or is redeemed.
+7. Allow pull-to-refresh / retry so the screen can recover if new donor capacity appears.
+
+## Decision Rules
+
+SlugSwap should treat these outcomes differently:
+
+1. If the requester lacks allowance, return `allowance_exhausted`.
+2. If allowance exists but no donor can support a new claim under current pool rules, return `pool_exhausted`.
+3. If donor capacity may exist but code generation fails because GET Tools or donor access is down, return `pool_unavailable`.
+
+This avoids telling users "we're out of points" when the real problem is a transient systems issue.
+
+## Operational Behavior
+
+### Low-points warning
+
+SlugSwap should warn before full exhaustion. The exact threshold can be tuned later, but the product requirement is:
+
+- Show `pool_low` before `pool_exhausted`.
+- Do not wait until the final failed generate attempt to tell users supply is tight.
+
+### Weekly reset
+
+- `allowance_exhausted` clears on the next weekly reset for that requester.
+- `pool_exhausted` clears when new usable donor capacity becomes available or the next weekly pool starts.
+
+### Fairness
+
+- Unused requester allowance does not guarantee immediate claimability if the shared pool is empty.
+- The product should always message this clearly so "allowance" is understood as a ceiling, not a reservation.
+
+## API Contract Recommendation
+
+Claim-generation responses should include a machine-readable reason so mobile can render the correct state:
+
+- `allowance_exhausted`
+- `pool_low`
+- `pool_exhausted`
+- `pool_unavailable`
+
+Suggested response shape on failure:
+
+```json
+{
+  "error": "No shared points available right now",
+  "reason": "pool_exhausted"
+}
+```
+
+## Current Gap In The App
+
+Today, the requester flow already handles `allowance_exhausted`, but `pool_exhausted` is still surfaced as a generic claim-generation error. The next implementation step is to map donor-capacity failures to a dedicated reason and render an inline exhausted-pool state on the Request tab.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -123,6 +123,11 @@ export type DonorImpact = {
 };
 
 export type CheckoutRail = "points-or-bucks" | "flexi-dollars";
+export type ClaimGenerationFailureReason =
+  | 'allowance_exhausted'
+  | 'pool_low'
+  | 'pool_exhausted'
+  | 'pool_unavailable';
 
 type ClaimCodePayload = {
   id: string;
@@ -147,17 +152,47 @@ export type MobileUpdatePolicyResponse = {
   updatedAt: string;
 };
 
-async function readApiError(response: Response, fallback: string): Promise<string> {
+function normalizeClaimGenerationFailureReason(
+  reason: unknown
+): ClaimGenerationFailureReason | undefined {
+  if (
+    reason === 'allowance_exhausted' ||
+    reason === 'pool_low' ||
+    reason === 'pool_exhausted' ||
+    reason === 'pool_unavailable'
+  ) {
+    return reason;
+  }
+
+  return undefined;
+}
+
+async function readApiErrorPayload(
+  response: Response,
+  fallback: string
+): Promise<{ message: string; reason?: ClaimGenerationFailureReason }> {
   const bodyText = await response.text();
-  if (!bodyText) return fallback;
+  if (!bodyText) return { message: fallback };
 
   try {
-    const parsed = JSON.parse(bodyText) as { error?: string; message?: string };
-    return parsed.error || parsed.message || fallback;
+    const parsed = JSON.parse(bodyText) as {
+      error?: string;
+      message?: string;
+      reason?: unknown;
+    };
+    return {
+      message: parsed.error || parsed.message || fallback,
+      reason: normalizeClaimGenerationFailureReason(parsed.reason),
+    };
   } catch {
     // Some upstream failures return plain text (for example, Vercel 502 pages).
-    return bodyText.slice(0, 200) || fallback;
+    return { message: bodyText.slice(0, 200) || fallback };
   }
+}
+
+async function readApiError(response: Response, fallback: string): Promise<string> {
+  const payload = await readApiErrorPayload(response, fallback);
+  return payload.message;
 }
 
 async function getAuthHeaders(): Promise<HeadersInit> {
@@ -234,8 +269,10 @@ export async function generateClaimCode(userId: string, amount: number) {
   });
 
   if (!response.ok) {
-    const errorMessage = await readApiError(response, 'Failed to generate claim code');
-    throw new Error(errorMessage);
+    const { message, reason } = await readApiErrorPayload(response, 'Failed to generate claim code');
+    const error = new Error(message) as Error & { reason?: ClaimGenerationFailureReason };
+    error.reason = reason;
+    throw error;
   }
 
   return response.json() as Promise<{ success: boolean; claimCode: ClaimCodePayload }>;

--- a/slugswap-release.md
+++ b/slugswap-release.md
@@ -91,6 +91,7 @@ SlugSwap uses a pooled weekly model:
 - Acceptance criteria:
   - Requesters cannot claim above allowance.
   - Total claims cannot exceed available pool.
+  - Requester-visible states clearly distinguish `allowance exhausted`, `shared pool exhausted`, and `temporary school-system unavailability`.
 
 2. As the product owner, I need claim codes to be safe against abuse so trust remains high.
 - Acceptance criteria:


### PR DESCRIPTION
## Summary
- add a shared tracked-balance helper for GET accounts and auto-pause active donors when live tracked balance is 0 or below
- block claim generation from issuing new barcodes for depleted donors and filter them out of highest-balance ranking
- reuse the same balance sync in GET/admin balance fetch paths so donor status self-corrects on refresh

## Testing
- npm run dashboard:typecheck