### PR TITLE
Clarify GET API integration notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,14 @@ See `slugswap-release.md` for the detailed release plan.
 ## Contributing
 
 For questions, issues, or contribution guidance, contact the development team.
+
+## GET API integration notes
+
+The GET barcode flow currently **does not use a server-side session cache**. Each barcode fetch re-authenticates with GET using the stored device credentials/PIN and then requests the latest payload.
+
+For clients consuming claim/scan status:
+
+- `GET /api/get/scan-state` returns scan/status metadata only (`state`, `lastCheckedAt`, `expiresAt`).
+- Barcode payloads are returned by `GET /api/get/barcode`.
+
+Keep those endpoints separate in client logic to avoid treating scan-state responses as barcode payload responses.


### PR DESCRIPTION
### Motivation
- Address documentation inaccuracies in the GET workflow diagrams that implied a server-side session cache and that `scan-state` returns barcode payloads.

### Description
- Update `README.md` to add a `GET API integration notes` section clarifying that the barcode refresh flow does not use a server-side session cache and that `GET /api/get/scan-state` returns metadata only while `GET /api/get/barcode` returns barcode payloads, and note that clients should keep those endpoints separate.

### Testing
- Ran workspace type checking with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b75863337083208ab34c6fb984186a)