### PR TITLE
Clamp donor remaining by live GET balance

### DIFF
--- a/apps/dashboard/app/admin-dashboard-client.tsx
+++ b/apps/dashboard/app/admin-dashboard-client.tsx
@@ -158,7 +158,7 @@ type AdminUserBalanceResponse = {
     accountsFetchError: string | null;
   };
   getBalance: Array<{ id: string; accountDisplayName: string; balance: number | null }> | null;
-  trackedGetBalanceTotal: number;
+  trackedGetBalanceTotal: number | null;
   weeklyAllowance: {
     weeklyLimit: number;
     usedAmount: number;
@@ -1870,7 +1870,9 @@ export default function DashboardHomePage() {
                           <div className="config-item">
                             <div className="config-label">GET Tracked Balance</div>
                             <div style={{ color: "var(--text-primary)", fontWeight: 600 }}>
-                              {formatNum(selectedUserDetails.trackedGetBalanceTotal)} pts
+                              {selectedUserDetails.trackedGetBalanceTotal === null
+                                ? "Unavailable"
+                                : `${formatNum(selectedUserDetails.trackedGetBalanceTotal)} pts`}
                             </div>
                             <div style={{ color: "var(--text-muted)", fontSize: "0.8rem", marginTop: 4 }}>
                               Flexi + Banana + Slug

--- a/apps/dashboard/app/api/admin/[action]/route.ts
+++ b/apps/dashboard/app/api/admin/[action]/route.ts
@@ -684,10 +684,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
             const capRemainingThisWeek = usage?.capRemainingThisWeek ?? fallbackCap;
             const remainingThisWeek =
               typeof d.trackedGetBalanceTotal === "number"
-                ? Math.min(
-                    capRemainingThisWeek,
-                    Math.max(0, d.trackedGetBalanceTotal - reservedThisWeek)
-                  )
+                ? Math.min(capRemainingThisWeek, Math.max(0, d.trackedGetBalanceTotal))
                 : usage?.remainingThisWeek ?? fallbackCap;
             return {
               userId: d.userId,
@@ -957,10 +954,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
         const capRemainingThisWeek = weeklyAmount - (redeemedThisWeek + reservedThisWeek);
         const remainingThisWeek =
           typeof trackedGetBalanceTotal === "number"
-            ? Math.min(
-                capRemainingThisWeek,
-                Math.max(0, trackedGetBalanceTotal - reservedThisWeek)
-              )
+            ? Math.min(capRemainingThisWeek, Math.max(0, trackedGetBalanceTotal))
             : capRemainingThisWeek;
         donorUsage = {
           status: donation.status,

--- a/apps/dashboard/app/api/admin/[action]/route.ts
+++ b/apps/dashboard/app/api/admin/[action]/route.ts
@@ -680,10 +680,14 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
           topDonors: topDonorsWithGetBalance.map((d) => {
             const fallbackCap = parseFloat(d.amount);
             const usage = usageMap.get(d.userId);
+            const reservedThisWeek = usage?.reservedThisWeek ?? 0;
             const capRemainingThisWeek = usage?.capRemainingThisWeek ?? fallbackCap;
             const remainingThisWeek =
               typeof d.trackedGetBalanceTotal === "number"
-                ? Math.min(capRemainingThisWeek, Math.max(0, d.trackedGetBalanceTotal))
+                ? Math.min(
+                    capRemainingThisWeek,
+                    Math.max(0, d.trackedGetBalanceTotal - reservedThisWeek)
+                  )
                 : usage?.remainingThisWeek ?? fallbackCap;
             return {
               userId: d.userId,
@@ -695,7 +699,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
               trackedGetBalanceTotal: d.trackedGetBalanceTotal,
               capAmount: usage?.capAmount ?? fallbackCap,
               redeemedThisWeek: usage?.redeemedThisWeek ?? 0,
-              reservedThisWeek: usage?.reservedThisWeek ?? 0,
+              reservedThisWeek,
               remainingThisWeek,
               capReached: remainingThisWeek <= 0,
               utilizationRatio: usage?.utilizationRatio ?? 0,
@@ -792,7 +796,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
         }
       }
 
-      const trackedGetBalanceTotal = getTrackedBalanceTotal(getBalance ?? []) ?? 0;
+      const trackedGetBalanceTotal = getTrackedBalanceTotal(getBalance ?? []);
 
       // Weekly allowance
       const currentPool = await db
@@ -953,7 +957,10 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
         const capRemainingThisWeek = weeklyAmount - (redeemedThisWeek + reservedThisWeek);
         const remainingThisWeek =
           typeof trackedGetBalanceTotal === "number"
-            ? Math.min(capRemainingThisWeek, Math.max(0, trackedGetBalanceTotal))
+            ? Math.min(
+                capRemainingThisWeek,
+                Math.max(0, trackedGetBalanceTotal - reservedThisWeek)
+              )
             : capRemainingThisWeek;
         donorUsage = {
           status: donation.status,

--- a/apps/dashboard/app/api/admin/[action]/route.ts
+++ b/apps/dashboard/app/api/admin/[action]/route.ts
@@ -680,6 +680,11 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
           topDonors: topDonorsWithGetBalance.map((d) => {
             const fallbackCap = parseFloat(d.amount);
             const usage = usageMap.get(d.userId);
+            const capRemainingThisWeek = usage?.capRemainingThisWeek ?? fallbackCap;
+            const remainingThisWeek =
+              typeof d.trackedGetBalanceTotal === "number"
+                ? Math.min(capRemainingThisWeek, Math.max(0, d.trackedGetBalanceTotal))
+                : usage?.remainingThisWeek ?? fallbackCap;
             return {
               userId: d.userId,
               name: d.userName || "Anonymous",
@@ -691,8 +696,8 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
               capAmount: usage?.capAmount ?? fallbackCap,
               redeemedThisWeek: usage?.redeemedThisWeek ?? 0,
               reservedThisWeek: usage?.reservedThisWeek ?? 0,
-              remainingThisWeek: usage?.remainingThisWeek ?? fallbackCap,
-              capReached: usage?.capReached ?? false,
+              remainingThisWeek,
+              capReached: remainingThisWeek <= 0,
               utilizationRatio: usage?.utilizationRatio ?? 0,
             };
           }),
@@ -945,12 +950,17 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
 
         const redeemedThisWeek = parseFloat(donorRedeemedWeek[0]?.total || "0");
         const reservedThisWeek = parseFloat(donorReservedWeek[0]?.total || "0");
+        const capRemainingThisWeek = weeklyAmount - (redeemedThisWeek + reservedThisWeek);
+        const remainingThisWeek =
+          typeof trackedGetBalanceTotal === "number"
+            ? Math.min(capRemainingThisWeek, Math.max(0, trackedGetBalanceTotal))
+            : capRemainingThisWeek;
         donorUsage = {
           status: donation.status,
           weeklyAmount,
           redeemedThisWeek,
           reservedThisWeek,
-          remainingThisWeek: weeklyAmount - (redeemedThisWeek + reservedThisWeek),
+          remainingThisWeek,
           allTimeRedeemedAmount: parseFloat(donorAllTimeRedeemed[0]?.totalAmount || "0"),
           allTimeRedeemedCount: Number(donorAllTimeRedeemed[0]?.count || 0),
         };

--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -85,15 +85,14 @@ function toSafeBalance(value: number | null): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-function getAvailableTrackedBalanceAfterReservations(
-  trackedBalance: number | null,
-  reservedThisWeek: number
+function getAvailableTrackedBalance(
+  trackedBalance: number | null
 ): number | null {
   if (typeof trackedBalance !== "number" || Number.isNaN(trackedBalance)) {
     return null;
   }
 
-  return Math.max(0, trackedBalance - reservedThisWeek);
+  return Math.max(0, trackedBalance);
 }
 
 function chooseCheckoutRail(
@@ -251,10 +250,7 @@ async function handleGenerate(req: NextRequest) {
           accounts
         );
 
-        const availableTrackedBalance = getAvailableTrackedBalanceAfterReservations(
-          trackedBalance,
-          usage.reservedThisWeek
-        );
+        const availableTrackedBalance = getAvailableTrackedBalance(trackedBalance);
 
         if (availableTrackedBalance != null && availableTrackedBalance < claimAmount) {
           hadDepletedBalanceReject = true;

--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -85,6 +85,17 @@ function toSafeBalance(value: number | null): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
+function getAvailableTrackedBalanceAfterReservations(
+  trackedBalance: number | null,
+  reservedThisWeek: number
+): number | null {
+  if (typeof trackedBalance !== "number" || Number.isNaN(trackedBalance)) {
+    return null;
+  }
+
+  return Math.max(0, trackedBalance - reservedThisWeek);
+}
+
 function chooseCheckoutRail(
   snapshot: BalanceSnapshotEntry[],
   claimAmount: number
@@ -240,7 +251,12 @@ async function handleGenerate(req: NextRequest) {
           accounts
         );
 
-        if (trackedBalance != null && trackedBalance <= 0) {
+        const availableTrackedBalance = getAvailableTrackedBalanceAfterReservations(
+          trackedBalance,
+          usage.reservedThisWeek
+        );
+
+        if (availableTrackedBalance != null && availableTrackedBalance < claimAmount) {
           hadDepletedBalanceReject = true;
           continue;
         }

--- a/apps/dashboard/app/api/donations/[action]/route.ts
+++ b/apps/dashboard/app/api/donations/[action]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, eq, gte, lt, sql as sqlOp } from "drizzle-orm";
 import { db } from "@/lib/server/db";
 import * as schema from "@/lib/server/schema";
+import { fetchLiveTrackedBalance } from "@/lib/server/get/tracked-balance";
 import { getPacificWeekWindow } from "@/lib/server/timezone";
 
 export const runtime = "nodejs";
@@ -179,7 +180,19 @@ async function handleImpact(req: NextRequest) {
 
     const redeemedWeekAmount = parseFloat(redeemedThisWeek[0]?.total || "0");
     const reservedWeekAmount = parseFloat(reservedThisWeek[0]?.total || "0");
-    const remainingThisWeek = weeklyAmount - (redeemedWeekAmount + reservedWeekAmount);
+    const capRemainingThisWeek = weeklyAmount - (redeemedWeekAmount + reservedWeekAmount);
+
+    let remainingThisWeek = capRemainingThisWeek;
+
+    try {
+      const liveTrackedBalance = await fetchLiveTrackedBalance(userId);
+      if (typeof liveTrackedBalance === "number" && !Number.isNaN(liveTrackedBalance)) {
+        remainingThisWeek = Math.min(capRemainingThisWeek, Math.max(0, liveTrackedBalance));
+      }
+    } catch (error) {
+      console.warn(`Failed to fetch live GET balance for donor ${userId}:`, error);
+    }
+    const capReached = remainingThisWeek <= 0;
 
     return NextResponse.json(
       {
@@ -192,7 +205,7 @@ async function handleImpact(req: NextRequest) {
         redeemedThisWeek: redeemedWeekAmount,
         reservedThisWeek: reservedWeekAmount,
         remainingThisWeek,
-        capReached: remainingThisWeek <= 0,
+        capReached,
         weekStart: weekWindow.weekStart.toISOString(),
         weekEnd: weekWindow.weekEnd.toISOString(),
         timezone: weekWindow.timezone,

--- a/apps/dashboard/app/api/donations/[action]/route.ts
+++ b/apps/dashboard/app/api/donations/[action]/route.ts
@@ -187,10 +187,7 @@ async function handleImpact(req: NextRequest) {
     try {
       const liveTrackedBalance = await fetchLiveTrackedBalance(userId);
       if (typeof liveTrackedBalance === "number" && !Number.isNaN(liveTrackedBalance)) {
-        remainingThisWeek = Math.min(
-          capRemainingThisWeek,
-          Math.max(0, liveTrackedBalance - reservedWeekAmount)
-        );
+        remainingThisWeek = Math.min(capRemainingThisWeek, Math.max(0, liveTrackedBalance));
       }
     } catch (error) {
       console.warn(`Failed to fetch live GET balance for donor ${userId}:`, error);

--- a/apps/dashboard/app/api/donations/[action]/route.ts
+++ b/apps/dashboard/app/api/donations/[action]/route.ts
@@ -187,7 +187,10 @@ async function handleImpact(req: NextRequest) {
     try {
       const liveTrackedBalance = await fetchLiveTrackedBalance(userId);
       if (typeof liveTrackedBalance === "number" && !Number.isNaN(liveTrackedBalance)) {
-        remainingThisWeek = Math.min(capRemainingThisWeek, Math.max(0, liveTrackedBalance));
+        remainingThisWeek = Math.min(
+          capRemainingThisWeek,
+          Math.max(0, liveTrackedBalance - reservedWeekAmount)
+        );
       }
     } catch (error) {
       console.warn(`Failed to fetch live GET balance for donor ${userId}:`, error);

--- a/apps/dashboard/lib/server/claims/donor-selection.ts
+++ b/apps/dashboard/lib/server/claims/donor-selection.ts
@@ -2,17 +2,13 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/server/db";
 import { donations, getCredentials } from "@/lib/server/schema";
 import {
+  applyLiveTrackedBalance,
   getDonorWeeklyUsageMap,
   type DonorWeeklyUsage,
 } from "@/lib/server/claims/donor-usage";
-import { getActiveGetSession } from "@/lib/server/get/session";
-import { retrieveAccounts } from "@/lib/server/get/tools";
-import {
-  getTrackedBalanceTotal,
-  syncDonorPauseStateFromAccounts,
-} from "@/lib/server/get/tracked-balance";
 import { getAdminConfig, type DonorSelectionPolicy } from "@/lib/server/config";
 import { type WeekWindow } from "@/lib/server/timezone";
+import { fetchLiveTrackedBalance } from "@/lib/server/get/tracked-balance";
 
 export type RankedDonorCandidate = {
   donorUserId: string;
@@ -30,18 +26,6 @@ export type RankedDonorSelection = {
 function parsePoints(value: string | number): number {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
-}
-
-async function fetchLiveTrackedBalance(donorUserId: string): Promise<number | null> {
-  try {
-    const { sessionId } = await getActiveGetSession(donorUserId);
-    const accounts = await retrieveAccounts(sessionId);
-    const { trackedBalance } = await syncDonorPauseStateFromAccounts(donorUserId, accounts);
-    return trackedBalance ?? getTrackedBalanceTotal(accounts);
-  } catch (error) {
-    console.warn(`Failed to retrieve live balance for donor ${donorUserId}:`, error);
-    return null;
-  }
 }
 
 function roundRobinSort(a: RankedDonorCandidate, b: RankedDonorCandidate): number {
@@ -101,7 +85,7 @@ export async function rankDonorCandidatesForClaim(
 
   const { usageMap, weekWindow } = await getDonorWeeklyUsageMap(donorCaps, now);
 
-  let candidates: RankedDonorCandidate[] = donorRows
+  const candidatesWithUsage: RankedDonorCandidate[] = donorRows
     .map((row) => {
       const weeklyAmount = parsePoints(row.weeklyAmount);
       const usage = usageMap.get(row.donorUserId);
@@ -114,7 +98,31 @@ export async function rankDonorCandidatesForClaim(
       } as RankedDonorCandidate;
     })
     .filter((candidate): candidate is RankedDonorCandidate => !!candidate)
-    .filter((candidate) => candidate.usage.remainingThisWeek >= claimAmount);
+    .filter((candidate) => candidate.usage.capRemainingThisWeek >= claimAmount);
+
+  if (candidatesWithUsage.length === 0) {
+    throw new Error("No eligible donors available under weekly cap limits.");
+  }
+
+  const withBalances = await Promise.all(
+    candidatesWithUsage.map(async (candidate) => {
+      try {
+        const liveTrackedBalance = await fetchLiveTrackedBalance(candidate.donorUserId);
+        return {
+          ...candidate,
+          liveTrackedBalance,
+          usage: applyLiveTrackedBalance(candidate.usage, liveTrackedBalance),
+        };
+      } catch (error) {
+        console.warn(`Failed to retrieve live balance for donor ${candidate.donorUserId}:`, error);
+        return candidate;
+      }
+    })
+  );
+
+  let candidates = withBalances.filter(
+    (candidate) => candidate.usage.remainingThisWeek >= claimAmount
+  );
 
   if (candidates.length === 0) {
     throw new Error("No eligible donors available under weekly cap limits.");
@@ -129,25 +137,9 @@ export async function rankDonorCandidatesForClaim(
   } else if (policy === "least_utilized") {
     candidates.sort(leastUtilizedSort);
   } else {
-    const withBalances = await Promise.all(
-      candidates.map(async (candidate) => ({
-        ...candidate,
-        liveTrackedBalance: await fetchLiveTrackedBalance(candidate.donorUserId),
-      }))
-    );
-
-    const hasLiveBalance = withBalances.some(
+    const hasLiveBalance = candidates.some(
       (candidate) => typeof candidate.liveTrackedBalance === "number"
     );
-
-    candidates = withBalances.filter(
-      (candidate) =>
-        candidate.liveTrackedBalance == null || candidate.liveTrackedBalance > 0
-    );
-
-    if (candidates.length === 0) {
-      throw new Error("No eligible donors available under weekly cap limits.");
-    }
 
     if (hasLiveBalance) {
       candidates.sort(highestBalanceSort);

--- a/apps/dashboard/lib/server/claims/donor-selection.ts
+++ b/apps/dashboard/lib/server/claims/donor-selection.ts
@@ -104,31 +104,8 @@ export async function rankDonorCandidatesForClaim(
     throw new Error("No eligible donors available under weekly cap limits.");
   }
 
-  const withBalances = await Promise.all(
-    candidatesWithUsage.map(async (candidate) => {
-      try {
-        const liveTrackedBalance = await fetchLiveTrackedBalance(candidate.donorUserId);
-        return {
-          ...candidate,
-          liveTrackedBalance,
-          usage: applyLiveTrackedBalance(candidate.usage, liveTrackedBalance),
-        };
-      } catch (error) {
-        console.warn(`Failed to retrieve live balance for donor ${candidate.donorUserId}:`, error);
-        return candidate;
-      }
-    })
-  );
-
-  let candidates = withBalances.filter(
-    (candidate) => candidate.usage.remainingThisWeek >= claimAmount
-  );
-
-  if (candidates.length === 0) {
-    throw new Error("No eligible donors available under weekly cap limits.");
-  }
-
   const policy = config.donorSelectionPolicy;
+  let candidates = candidatesWithUsage;
 
   if (policy === "round_robin") {
     candidates.sort(roundRobinSort);
@@ -137,6 +114,33 @@ export async function rankDonorCandidatesForClaim(
   } else if (policy === "least_utilized") {
     candidates.sort(leastUtilizedSort);
   } else {
+    const withBalances = await Promise.all(
+      candidatesWithUsage.map(async (candidate) => {
+        try {
+          const liveTrackedBalance = await fetchLiveTrackedBalance(candidate.donorUserId);
+          return {
+            ...candidate,
+            liveTrackedBalance,
+            usage: applyLiveTrackedBalance(candidate.usage, liveTrackedBalance),
+          };
+        } catch (error) {
+          console.warn(
+            `Failed to retrieve live balance for donor ${candidate.donorUserId}:`,
+            error
+          );
+          return candidate;
+        }
+      })
+    );
+
+    candidates = withBalances.filter(
+      (candidate) => candidate.usage.remainingThisWeek >= claimAmount
+    );
+
+    if (candidates.length === 0) {
+      throw new Error("No eligible donors available under weekly cap limits.");
+    }
+
     const hasLiveBalance = candidates.some(
       (candidate) => typeof candidate.liveTrackedBalance === "number"
     );

--- a/apps/dashboard/lib/server/claims/donor-usage.ts
+++ b/apps/dashboard/lib/server/claims/donor-usage.ts
@@ -1,6 +1,6 @@
 import { and, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/server/db";
-import { claimCodes } from "@/lib/server/schema";
+import { claimCodes, donations } from "@/lib/server/schema";
 import { getPacificWeekWindow, type WeekWindow } from "@/lib/server/timezone";
 
 export type DonorCapInput = {
@@ -15,10 +15,12 @@ export type DonorWeeklyUsage = {
   reservedThisWeek: number;
   claimsSelectedThisWeek: number;
   committedThisWeek: number;
+  capRemainingThisWeek: number;
   remainingThisWeek: number;
   capReached: boolean;
   lastSelectedAt: Date | null;
   utilizationRatio: number;
+  liveTrackedBalance: number | null;
 };
 
 function toNumeric(value: string | number | null | undefined): number {
@@ -37,7 +39,7 @@ export function computeUsageFromValues(input: {
 }): DonorWeeklyUsage {
   const capAmount = Math.max(0, input.capAmount);
   const committedThisWeek = input.redeemedThisWeek + input.reservedThisWeek;
-  const remainingThisWeek = capAmount - committedThisWeek;
+  const capRemainingThisWeek = capAmount - committedThisWeek;
   return {
     donorUserId: input.donorUserId,
     capAmount,
@@ -45,10 +47,31 @@ export function computeUsageFromValues(input: {
     reservedThisWeek: input.reservedThisWeek,
     claimsSelectedThisWeek: input.claimsSelectedThisWeek,
     committedThisWeek,
-    remainingThisWeek,
-    capReached: remainingThisWeek <= 0,
+    capRemainingThisWeek,
+    remainingThisWeek: capRemainingThisWeek,
+    capReached: capRemainingThisWeek <= 0,
     lastSelectedAt: input.lastSelectedAt,
     utilizationRatio: capAmount > 0 ? committedThisWeek / capAmount : Number.POSITIVE_INFINITY,
+    liveTrackedBalance: null,
+  };
+}
+
+export function applyLiveTrackedBalance(
+  usage: DonorWeeklyUsage,
+  liveTrackedBalance: number | null | undefined
+): DonorWeeklyUsage {
+  if (typeof liveTrackedBalance !== "number" || Number.isNaN(liveTrackedBalance)) {
+    return usage;
+  }
+
+  const constrainedBalance = Math.max(0, liveTrackedBalance);
+  const remainingThisWeek = Math.min(usage.capRemainingThisWeek, constrainedBalance);
+
+  return {
+    ...usage,
+    liveTrackedBalance: constrainedBalance,
+    remainingThisWeek,
+    capReached: remainingThisWeek <= 0,
   };
 }
 
@@ -165,4 +188,30 @@ export async function getDonorWeeklyUsageMap(
     usageMap,
     weekWindow: window,
   };
+}
+
+export async function getActiveDonorRemainingTotal(now = new Date()): Promise<number> {
+  const donorRows = await db
+    .select({
+      donorUserId: donations.userId,
+      capAmount: donations.amount,
+    })
+    .from(donations)
+    .where(eq(donations.status, "active"));
+
+  if (donorRows.length === 0) {
+    return 0;
+  }
+
+  const donorCaps = donorRows.map((row) => ({
+    donorUserId: row.donorUserId,
+    capAmount: toNumeric(row.capAmount),
+  }));
+
+  const { usageMap } = await getDonorWeeklyUsageMap(donorCaps, now);
+
+  return donorCaps.reduce((sum, donor) => {
+    const remaining = usageMap.get(donor.donorUserId)?.remainingThisWeek ?? 0;
+    return sum + Math.max(0, remaining);
+  }, 0);
 }

--- a/apps/dashboard/lib/server/claims/donor-usage.ts
+++ b/apps/dashboard/lib/server/claims/donor-usage.ts
@@ -65,10 +65,7 @@ export function applyLiveTrackedBalance(
   }
 
   const constrainedBalance = Math.max(0, liveTrackedBalance);
-  // Active claims have not reduced GET yet, so keep their reservations out of the
-  // donor's effective live balance before we compare against cap-based remaining.
-  const availableLiveBalance = Math.max(0, constrainedBalance - usage.reservedThisWeek);
-  const remainingThisWeek = Math.min(usage.capRemainingThisWeek, availableLiveBalance);
+  const remainingThisWeek = Math.min(usage.capRemainingThisWeek, constrainedBalance);
 
   return {
     ...usage,

--- a/apps/dashboard/lib/server/claims/donor-usage.ts
+++ b/apps/dashboard/lib/server/claims/donor-usage.ts
@@ -65,7 +65,10 @@ export function applyLiveTrackedBalance(
   }
 
   const constrainedBalance = Math.max(0, liveTrackedBalance);
-  const remainingThisWeek = Math.min(usage.capRemainingThisWeek, constrainedBalance);
+  // Active claims have not reduced GET yet, so keep their reservations out of the
+  // donor's effective live balance before we compare against cap-based remaining.
+  const availableLiveBalance = Math.max(0, constrainedBalance - usage.reservedThisWeek);
+  const remainingThisWeek = Math.min(usage.capRemainingThisWeek, availableLiveBalance);
 
   return {
     ...usage,

--- a/apps/dashboard/lib/server/get/tracked-balance.ts
+++ b/apps/dashboard/lib/server/get/tracked-balance.ts
@@ -1,7 +1,9 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/server/db";
 import { donations } from "@/lib/server/schema";
+import { getActiveGetSession } from "@/lib/server/get/session";
 import { type GetAccount } from "@/lib/server/get/tools";
+import { retrieveAccounts } from "@/lib/server/get/tools";
 
 export const TRACKED_BALANCE_ACCOUNT_NAMES = new Set([
   "flexi dollars",
@@ -47,4 +49,13 @@ export async function syncDonorPauseStateFromAccounts(
     trackedBalance,
     autoPaused: !!updated,
   };
+}
+
+export async function fetchLiveTrackedBalance(
+  donorUserId: string
+): Promise<number | null> {
+  const { sessionId } = await getActiveGetSession(donorUserId);
+  const accounts = await retrieveAccounts(sessionId);
+  const { trackedBalance } = await syncDonorPauseStateFromAccounts(donorUserId, accounts);
+  return trackedBalance ?? getTrackedBalanceTotal(accounts);
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -439,7 +439,7 @@ export async function getUserBalance(params: { name?: string; email?: string; us
       accountsFetchError: string | null;
     };
     getBalance: Array<{ id: string; accountDisplayName: string; balance: number | null }> | null;
-    trackedGetBalanceTotal: number;
+    trackedGetBalanceTotal: number | null;
     weeklyAllowance: {
       weeklyLimit: number;
       usedAmount: number;


### PR DESCRIPTION
## Summary\n- Clamp donor remaining to the lower of weekly cap remainder and live tracked GET balance\n- Apply the same constraint in donor selection so claim routing does not overcommit donors with low balances\n- Keep admin donor views aligned with the live GET balance\n\n## Verification\n- 
> slugswap-workspace@1.0.0 dashboard:typecheck
> npm run typecheck -w @slugswap/dashboard


> typecheck
> tsc --noEmit