### PR TITLE
Make GET-style skin the default and fix scan card flow

### DIFF
--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -35,6 +35,16 @@ function durationMs(startedAt: number): number {
   return Date.now() - startedAt;
 }
 
+function logClaimGenerationTiming(payload: Record<string, unknown>) {
+  if (process.env.NODE_ENV === "production") return;
+  console.info("[claims.generate.timing]", payload);
+}
+
+function logClaimCandidateFailure(payload: Record<string, unknown>) {
+  if (process.env.NODE_ENV === "production") return;
+  console.warn("[claims.generate.candidate-failure]", payload);
+}
+
 function claimGenerationErrorResponse(
   error: string,
   status: number,
@@ -330,7 +340,7 @@ async function handleGenerate(req: NextRequest) {
         // Allowance is NOT deducted here — it's only deducted when redemption
         // is confirmed via balance drop (the actual amount spent may differ).
 
-        console.info("[claims.generate.timing]", {
+        logClaimGenerationTiming({
           requesterUserId: userId,
           donorUserId: candidate.donorUserId,
           donorSelectionPolicy: ranked.policy,
@@ -365,7 +375,7 @@ async function handleGenerate(req: NextRequest) {
           { status: 200 }
         );
       } catch (error: any) {
-        console.warn("[claims.generate.candidate-failure]", {
+        logClaimCandidateFailure({
           requesterUserId: userId,
           donorUserId: candidate.donorUserId,
           donorSelectionPolicy: ranked.policy,
@@ -405,7 +415,7 @@ async function handleGenerate(req: NextRequest) {
     );
   } catch (error: any) {
     console.error("Error generating claim code:", error);
-    console.info("[claims.generate.timing]", {
+    logClaimGenerationTiming({
       requestTotalMs: durationMs(requestStartedAt),
       failed: true,
     });

--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createClient, type User } from "@supabase/supabase-js";
 import { and, desc, eq } from "drizzle-orm";
 import { db } from "@/lib/server/db";
 import * as schema from "@/lib/server/schema";
@@ -166,6 +167,67 @@ function getCurrentWeek() {
   return { weekStart, weekEnd };
 }
 
+function getSupabaseClient() {
+  const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Supabase environment variables not configured");
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey);
+}
+
+function unauthorizedResponse(message = "Unauthorized") {
+  return NextResponse.json({ error: message }, { status: 401 });
+}
+
+async function authenticateAppUser(
+  req: NextRequest
+): Promise<{ user: User } | { response: NextResponse }> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader) {
+    return { response: unauthorizedResponse() };
+  }
+
+  const token = authHeader.replace("Bearer ", "").trim();
+  if (!token) {
+    return { response: unauthorizedResponse("Invalid token") };
+  }
+
+  const supabase = getSupabaseClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser(token);
+
+  if (error || !user?.id) {
+    return { response: unauthorizedResponse("Invalid token") };
+  }
+
+  return { user };
+}
+
+async function syncAuthenticatedUser(user: User) {
+  await db
+    .insert(schema.users)
+    .values({
+      id: user.id,
+      email: user.email || `${user.id}@unknown.local`,
+      name: user.user_metadata?.name || null,
+      avatarUrl: user.user_metadata?.avatar_url || null,
+    })
+    .onConflictDoUpdate({
+      target: schema.users.id,
+      set: {
+        email: user.email || `${user.id}@unknown.local`,
+        name: user.user_metadata?.name || null,
+        avatarUrl: user.user_metadata?.avatar_url || null,
+        updatedAt: new Date(),
+      },
+    });
+}
+
 async function handleGenerate(req: NextRequest) {
   if (req.method !== "POST") {
     return NextResponse.json({ error: "Method not allowed" }, { status: 405 });
@@ -174,13 +236,19 @@ async function handleGenerate(req: NextRequest) {
   const requestStartedAt = Date.now();
 
   try {
-    const { userId, amount } = (await req.json()) as {
-      userId?: string;
+    const auth = await authenticateAppUser(req);
+    if ("response" in auth) {
+      return auth.response;
+    }
+    await syncAuthenticatedUser(auth.user);
+
+    const { amount } = (await req.json()) as {
       amount?: number | string;
     };
+    const userId = auth.user.id;
 
-    if (!userId || !amount) {
-      return NextResponse.json({ error: "Missing userId or amount" }, { status: 400 });
+    if (!amount) {
+      return NextResponse.json({ error: "Missing amount" }, { status: 400 });
     }
 
     const claimAmount = parseFloat(String(amount));
@@ -207,8 +275,22 @@ async function handleGenerate(req: NextRequest) {
           allocatedAmount: "0",
           remainingAmount: "0",
         })
+        .onConflictDoNothing({ target: schema.weeklyPools.weekStart })
         .returning();
-      weeklyPool = [newPool];
+
+      if (newPool) {
+        weeklyPool = [newPool];
+      } else {
+        weeklyPool = await db
+          .select()
+          .from(schema.weeklyPools)
+          .where(eq(schema.weeklyPools.weekStart, weekStart))
+          .limit(1);
+      }
+
+      if (weeklyPool.length === 0) {
+        throw new Error("Failed to load weekly pool");
+      }
     }
 
     let userAllowance = await db
@@ -435,10 +517,11 @@ async function handleHistory(req: NextRequest) {
   }
 
   try {
-    const userId = new URL(req.url).searchParams.get("userId");
-    if (!userId) {
-      return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+    const auth = await authenticateAppUser(req);
+    if ("response" in auth) {
+      return auth.response;
     }
+    const userId = auth.user.id;
 
     const claimCodes = await db
       .select()
@@ -474,13 +557,19 @@ async function handleRefresh(req: NextRequest) {
   }
 
   try {
-    const { userId, claimCodeId } = (await req.json()) as {
-      userId?: string;
+    const auth = await authenticateAppUser(req);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const { claimCodeId } = (await req.json()) as {
       claimCodeId?: string;
     };
-    if (!userId || !claimCodeId) {
+    const userId = auth.user.id;
+
+    if (!claimCodeId) {
       return NextResponse.json(
-        { error: "Missing userId or claimCodeId" },
+        { error: "Missing claimCodeId" },
         { status: 400 }
       );
     }
@@ -554,14 +643,19 @@ async function handleDelete(req: NextRequest) {
   }
 
   try {
-    const { userId, claimCodeId } = (await req.json()) as {
-      userId?: string;
+    const auth = await authenticateAppUser(req);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const { claimCodeId } = (await req.json()) as {
       claimCodeId?: string;
     };
+    const userId = auth.user.id;
 
-    if (!userId || !claimCodeId) {
+    if (!claimCodeId) {
       return NextResponse.json(
-        { error: "Missing userId or claimCodeId" },
+        { error: "Missing claimCodeId" },
         { status: 400 }
       );
     }
@@ -690,13 +784,19 @@ async function handleCheckRedemption(req: NextRequest) {
   }
 
   try {
-    const { userId, claimCodeId } = (await req.json()) as {
-      userId?: string;
+    const auth = await authenticateAppUser(req);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const { claimCodeId } = (await req.json()) as {
       claimCodeId?: string;
     };
-    if (!userId || !claimCodeId) {
+    const userId = auth.user.id;
+
+    if (!claimCodeId) {
       return NextResponse.json(
-        { error: "Missing userId or claimCodeId" },
+        { error: "Missing claimCodeId" },
         { status: 400 }
       );
     }

--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -9,6 +9,7 @@ import {
   getDonorUsageForDonor,
   rankDonorCandidatesForClaim,
 } from "@/lib/server/claims/donor-selection";
+import { getAdminConfig } from "@/lib/server/config";
 import { retrieveAccounts, type GetAccount } from "@/lib/server/get/tools";
 import { getActiveGetSession } from "@/lib/server/get/session";
 import { syncDonorPauseStateFromAccounts } from "@/lib/server/get/tracked-balance";
@@ -29,6 +30,10 @@ const POOL_EXHAUSTED_MESSAGE =
   "Your personal allowance is still there, but the shared pool is empty. Check back later.";
 const POOL_UNAVAILABLE_MESSAGE =
   "Points are temporarily unavailable right now. Please try again in a moment.";
+
+function durationMs(startedAt: number): number {
+  return Date.now() - startedAt;
+}
 
 function claimGenerationErrorResponse(
   error: string,
@@ -156,6 +161,8 @@ async function handleGenerate(req: NextRequest) {
     return NextResponse.json({ error: "Method not allowed" }, { status: 405 });
   }
 
+  const requestStartedAt = Date.now();
+
   try {
     const { userId, amount } = (await req.json()) as {
       userId?: string;
@@ -171,18 +178,30 @@ async function handleGenerate(req: NextRequest) {
       return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
     }
 
+    const requesterStateStartedAt = Date.now();
     const { weekStart } = getCurrentWeek();
-    const weeklyPool = await db
+    let weeklyPool = await db
       .select()
       .from(schema.weeklyPools)
       .where(eq(schema.weeklyPools.weekStart, weekStart))
       .limit(1);
 
     if (weeklyPool.length === 0) {
-      return NextResponse.json({ error: "No active weekly pool" }, { status: 400 });
+      const { weekEnd } = getCurrentWeek();
+      const [newPool] = await db
+        .insert(schema.weeklyPools)
+        .values({
+          weekStart,
+          weekEnd,
+          totalAmount: "0",
+          allocatedAmount: "0",
+          remainingAmount: "0",
+        })
+        .returning();
+      weeklyPool = [newPool];
     }
 
-    const userAllowance = await db
+    let userAllowance = await db
       .select()
       .from(schema.userAllowances)
       .where(
@@ -194,10 +213,19 @@ async function handleGenerate(req: NextRequest) {
       .limit(1);
 
     if (userAllowance.length === 0) {
-      return NextResponse.json(
-        { error: "No allowance found for this week" },
-        { status: 400 }
-      );
+      const { config } = await getAdminConfig();
+      const defaultWeeklyLimit = config.defaultWeeklyAllowance;
+      const [newAllowance] = await db
+        .insert(schema.userAllowances)
+        .values({
+          userId,
+          weeklyPoolId: weeklyPool[0].id,
+          weeklyLimit: defaultWeeklyLimit.toString(),
+          usedAmount: "0",
+          remainingAmount: defaultWeeklyLimit.toString(),
+        })
+        .returning();
+      userAllowance = [newAllowance];
     }
 
     const allowance = userAllowance[0];
@@ -211,34 +239,53 @@ async function handleGenerate(req: NextRequest) {
       );
     }
 
+    const requesterStateMs = durationMs(requesterStateStartedAt);
+    const rankingStartedAt = Date.now();
     const ranked = await rankDonorCandidatesForClaim(claimAmount);
+    const rankingMs = durationMs(rankingStartedAt);
     let hadCapReject = false;
     let hadDepletedBalanceReject = false;
     const fetchFailures: string[] = [];
 
-    for (const candidate of ranked.candidates) {
+    for (const [candidateIndex, candidate] of ranked.candidates.entries()) {
+      const candidateStartedAt = Date.now();
       // Re-check usage before reserving this donor to reduce race oversubscription.
+      const usageStartedAt = Date.now();
       const usage = await getDonorUsageForDonor(
         candidate.donorUserId,
         candidate.weeklyAmount,
         new Date(),
         ranked.weekWindow
       );
+      const usageCheckMs = durationMs(usageStartedAt);
 
       if (usage.remainingThisWeek < claimAmount) {
         hadCapReject = true;
         continue;
       }
 
+      let sessionMs: number | null = null;
+      let retrieveAccountsMs: number | null = null;
+      let pauseSyncMs: number | null = null;
+      let barcodeFetchMs: number | null = null;
+      let claimInsertMs: number | null = null;
+      let donorProfileMs: number | null = null;
+
       try {
+        const sessionStartedAt = Date.now();
         const { sessionId: donorSessionId } = await getActiveGetSession(
           candidate.donorUserId
         );
+        sessionMs = durationMs(sessionStartedAt);
+        const accountsStartedAt = Date.now();
         const accounts = await retrieveAccounts(donorSessionId);
+        retrieveAccountsMs = durationMs(accountsStartedAt);
+        const pauseSyncStartedAt = Date.now();
         const { trackedBalance } = await syncDonorPauseStateFromAccounts(
           candidate.donorUserId,
           accounts
         );
+        pauseSyncMs = durationMs(pauseSyncStartedAt);
 
         if (trackedBalance != null && trackedBalance <= 0) {
           hadDepletedBalanceReject = true;
@@ -248,11 +295,14 @@ async function handleGenerate(req: NextRequest) {
         const snapshot = toTrackedBalanceSnapshot(accounts);
         const balanceSnapshot = JSON.stringify(snapshot);
         const recommendedRail = chooseCheckoutRail(snapshot, claimAmount);
+        const barcodeStartedAt = Date.now();
         const { code, expiresAt } = await fetchLiveClaimCodeFromGet(
           candidate.donorUserId,
           donorSessionId
         );
+        barcodeFetchMs = durationMs(barcodeStartedAt);
 
+        const claimInsertStartedAt = Date.now();
         const [claimCode] = await db
           .insert(schema.claimCodes)
           .values({
@@ -266,16 +316,38 @@ async function handleGenerate(req: NextRequest) {
             balanceSnapshot,
           })
           .returning();
+        claimInsertMs = durationMs(claimInsertStartedAt);
 
+        const donorProfileStartedAt = Date.now();
         const donorProfile = await db
           .select({ name: schema.users.name })
           .from(schema.users)
           .where(eq(schema.users.id, candidate.donorUserId))
           .limit(1);
+        donorProfileMs = durationMs(donorProfileStartedAt);
         const donorDisplayName = formatDonorDisplayName(donorProfile[0]?.name ?? null);
 
         // Allowance is NOT deducted here — it's only deducted when redemption
         // is confirmed via balance drop (the actual amount spent may differ).
+
+        console.info("[claims.generate.timing]", {
+          requesterUserId: userId,
+          donorUserId: candidate.donorUserId,
+          donorSelectionPolicy: ranked.policy,
+          candidateIndex: candidateIndex + 1,
+          candidateCount: ranked.candidates.length,
+          requesterStateMs,
+          rankingMs,
+          usageCheckMs,
+          sessionMs,
+          retrieveAccountsMs,
+          pauseSyncMs,
+          barcodeFetchMs,
+          claimInsertMs,
+          donorProfileMs,
+          candidateTotalMs: durationMs(candidateStartedAt),
+          requestTotalMs: durationMs(requestStartedAt),
+        });
 
         return NextResponse.json(
           {
@@ -293,6 +365,24 @@ async function handleGenerate(req: NextRequest) {
           { status: 200 }
         );
       } catch (error: any) {
+        console.warn("[claims.generate.candidate-failure]", {
+          requesterUserId: userId,
+          donorUserId: candidate.donorUserId,
+          donorSelectionPolicy: ranked.policy,
+          candidateIndex: candidateIndex + 1,
+          candidateCount: ranked.candidates.length,
+          requesterStateMs,
+          rankingMs,
+          usageCheckMs,
+          sessionMs,
+          retrieveAccountsMs,
+          pauseSyncMs,
+          barcodeFetchMs,
+          claimInsertMs,
+          donorProfileMs,
+          candidateTotalMs: durationMs(candidateStartedAt),
+          message: error?.message || "Unknown donor barcode fetch error",
+        });
         fetchFailures.push(error?.message || "Unknown donor barcode fetch error");
       }
     }
@@ -315,6 +405,10 @@ async function handleGenerate(req: NextRequest) {
     );
   } catch (error: any) {
     console.error("Error generating claim code:", error);
+    console.info("[claims.generate.timing]", {
+      requestTotalMs: durationMs(requestStartedAt),
+      failed: true,
+    });
     const message = error?.message || "Internal server error";
     const classified = classifyClaimGenerationError(message);
     return claimGenerationErrorResponse(

--- a/apps/dashboard/lib/server/claims/donor-usage.ts
+++ b/apps/dashboard/lib/server/claims/donor-usage.ts
@@ -1,6 +1,6 @@
 import { and, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/server/db";
-import { claimCodes } from "@/lib/server/schema";
+import { claimCodes, donations, getCredentials } from "@/lib/server/schema";
 import { getPacificWeekWindow, type WeekWindow } from "@/lib/server/timezone";
 
 export type DonorCapInput = {
@@ -165,4 +165,35 @@ export async function getDonorWeeklyUsageMap(
     usageMap,
     weekWindow: window,
   };
+}
+
+export async function getActiveDonorRemainingTotal(now = new Date()): Promise<number> {
+  const donorRows = await db
+    .select({
+      donorUserId: donations.userId,
+      weeklyAmount: donations.amount,
+    })
+    .from(donations)
+    .innerJoin(getCredentials, eq(getCredentials.userId, donations.userId))
+    .where(eq(donations.status, "active"));
+
+  if (donorRows.length === 0) {
+    return 0;
+  }
+
+  const donorCaps = donorRows.map((row) => ({
+    donorUserId: row.donorUserId,
+    capAmount: toNumeric(row.weeklyAmount),
+  }));
+
+  const { usageMap } = await getDonorWeeklyUsageMap(donorCaps, now);
+
+  let totalRemaining = 0;
+  for (const donor of donorCaps) {
+    const usage = usageMap.get(donor.donorUserId);
+    if (!usage) continue;
+    totalRemaining += Math.max(0, usage.remainingThisWeek);
+  }
+
+  return totalRemaining;
 }

--- a/apps/dashboard/lib/server/claims/get-claim-code.ts
+++ b/apps/dashboard/lib/server/claims/get-claim-code.ts
@@ -7,6 +7,11 @@ function durationMs(startedAt: number): number {
   return Date.now() - startedAt;
 }
 
+function logBarcodeFetchTiming(payload: Record<string, unknown>) {
+  if (process.env.NODE_ENV === "production") return;
+  console.info("[claims.barcode-fetch.timing]", payload);
+}
+
 function extractBarcodePayload(raw: unknown): string | null {
   if (typeof raw === "string" && raw.trim()) return raw.trim();
   if (raw && typeof raw === "object") {
@@ -38,7 +43,7 @@ export async function fetchLiveClaimCodeFromGet(
   }
 
   const expiresAt = new Date(Date.now() + CLAIM_CODE_TTL_MS);
-  console.info("[claims.barcode-fetch.timing]", {
+  logBarcodeFetchTiming({
     userId,
     usedExistingSession: !!existingSessionId,
     getBarcodeMs: durationMs(fetchStartedAt),

--- a/apps/dashboard/lib/server/claims/get-claim-code.ts
+++ b/apps/dashboard/lib/server/claims/get-claim-code.ts
@@ -3,6 +3,10 @@ import { getActiveGetSession } from "@/lib/server/get/session";
 
 const CLAIM_CODE_TTL_MS = 60_000;
 
+function durationMs(startedAt: number): number {
+  return Date.now() - startedAt;
+}
+
 function extractBarcodePayload(raw: unknown): string | null {
   if (typeof raw === "string" && raw.trim()) return raw.trim();
   if (raw && typeof raw === "object") {
@@ -17,9 +21,11 @@ export async function fetchLiveClaimCodeFromGet(
   userId: string,
   existingSessionId?: string
 ): Promise<{ code: string; expiresAt: Date; sessionId: string }> {
+  const startedAt = Date.now();
   const { sessionId } = existingSessionId
     ? { sessionId: existingSessionId }
     : await getActiveGetSession(userId);
+  const fetchStartedAt = Date.now();
   const payload = await callGetApi<{ sessionId: string }, unknown>(
     "authentication",
     "retrievePatronBarcodePayload",
@@ -32,5 +38,11 @@ export async function fetchLiveClaimCodeFromGet(
   }
 
   const expiresAt = new Date(Date.now() + CLAIM_CODE_TTL_MS);
+  console.info("[claims.barcode-fetch.timing]", {
+    userId,
+    usedExistingSession: !!existingSessionId,
+    getBarcodeMs: durationMs(fetchStartedAt),
+    totalMs: durationMs(startedAt),
+  });
   return { code, expiresAt, sessionId };
 }

--- a/apps/dashboard/lib/server/get/session.ts
+++ b/apps/dashboard/lib/server/get/session.ts
@@ -4,9 +4,14 @@ import { getCredentials } from "@/lib/server/schema";
 import { decryptSecret } from "./credentials";
 import { authenticatePin, verifyPin } from "./tools";
 
+function durationMs(startedAt: number): number {
+  return Date.now() - startedAt;
+}
+
 export async function getActiveGetSession(
   userId: string
 ): Promise<{ sessionId: string; deviceId: string }> {
+  const startedAt = Date.now();
   const credential = await db.query.getCredentials.findFirst({
     where: eq(getCredentials.userId, userId),
   });
@@ -16,8 +21,17 @@ export async function getActiveGetSession(
   }
 
   const pin = decryptSecret(credential.encryptedPin);
+  const authStartedAt = Date.now();
   const sessionId = await authenticatePin(pin, credential.deviceId);
+  const verifyStartedAt = Date.now();
   await verifyPin(sessionId, credential.deviceId, pin);
+
+  console.info("[get.session.timing]", {
+    userId,
+    authMs: durationMs(authStartedAt),
+    verifyMs: durationMs(verifyStartedAt),
+    totalMs: durationMs(startedAt),
+  });
 
   return { sessionId, deviceId: credential.deviceId };
 }

--- a/apps/dashboard/lib/server/get/session.ts
+++ b/apps/dashboard/lib/server/get/session.ts
@@ -8,6 +8,11 @@ function durationMs(startedAt: number): number {
   return Date.now() - startedAt;
 }
 
+function logGetSessionTiming(payload: Record<string, unknown>) {
+  if (process.env.NODE_ENV === "production") return;
+  console.info("[get.session.timing]", payload);
+}
+
 export async function getActiveGetSession(
   userId: string
 ): Promise<{ sessionId: string; deviceId: string }> {
@@ -26,7 +31,7 @@ export async function getActiveGetSession(
   const verifyStartedAt = Date.now();
   await verifyPin(sessionId, credential.deviceId, pin);
 
-  console.info("[get.session.timing]", {
+  logGetSessionTiming({
     userId,
     authMs: durationMs(authStartedAt),
     verifyMs: durationMs(verifyStartedAt),

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -18,7 +18,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.anonymous.slugswap",
-      "buildNumber": "14",
+      "buildNumber": "15",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }

--- a/apps/mobile/app/(tabs)/(request)/index.tsx
+++ b/apps/mobile/app/(tabs)/(request)/index.tsx
@@ -1,21 +1,32 @@
-import { View, Text, Pressable, ScrollView, ActivityIndicator, Alert, RefreshControl } from 'react-native';
-import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
-import { BlurView } from 'expo-blur';
-import { SymbolView } from 'expo-symbols';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { SymbolView, type SymbolViewProps } from 'expo-symbols';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import { PDF417Barcode } from '../../../components/PDF417Barcode';
 import { supabase } from '../../../../../lib/supabase';
 import {
-  getRequesterAllowance,
+  checkRedemption,
   generateClaimCode,
   getClaimHistory,
+  getRequesterAllowance,
   refreshClaimCode,
-  checkRedemption,
   type CheckoutRail,
   type ClaimGenerationFailureReason,
 } from '../../../../../lib/api';
-import { PDF417Barcode } from '../../../components/PDF417Barcode';
 import { useTabCache } from '../../../../../lib/tab-cache-context';
-import { uiColor } from '../../../lib/ui-color';
+import { buttonOpacity, cardShadow, monoFontFamily, stealthTheme, typeScale } from '../../../lib/stealth-theme';
 
 interface ClaimCode {
   id: string;
@@ -69,31 +80,96 @@ function inferCheckoutRail(accountName?: string): CheckoutRail | null {
   return null;
 }
 
-function Card({ children, style }: { children: React.ReactNode; style?: any }) {
-  if (isLiquidGlassAvailable()) {
-    return (
-      <GlassView style={[{ borderRadius: 16, padding: 20 }, style]}>
-        {children}
-      </GlassView>
-    );
-  }
+function SectionCard({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+}) {
+  return <View style={[styles.sectionCard, style]}>{children}</View>;
+}
+
+function SectionHeader({
+  icon,
+  title,
+  detail,
+}: {
+  icon: SymbolViewProps['name'];
+  title: string;
+  detail?: string;
+}) {
   return (
-    <BlurView
-      tint="systemMaterial"
-      intensity={80}
-      style={[{
-        borderRadius: 16,
-        padding: 20,
-        overflow: 'hidden',
-      }, style]}
+    <View style={styles.sectionHeader}>
+      <View style={styles.sectionIcon}>
+        <SymbolView name={icon} tintColor={colors.textSoft} size={18} />
+      </View>
+      <View style={styles.sectionHeaderText}>
+        <Text style={styles.sectionTitle}>{title}</Text>
+        {detail ? <Text style={styles.sectionDetail}>{detail}</Text> : null}
+      </View>
+    </View>
+  );
+}
+
+function PrimaryAction({
+  label,
+  onPress,
+  disabled = false,
+  loading = false,
+  icon,
+  subtle = false,
+}: {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  icon?: SymbolViewProps['name'];
+  subtle?: boolean;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled || loading}
+      style={({ pressed }) => [
+        subtle ? styles.subtleButton : styles.primaryButton,
+        { opacity: buttonOpacity(pressed, disabled || loading) },
+      ]}
     >
-      {children}
-    </BlurView>
+      {loading ? (
+        <ActivityIndicator color={subtle ? colors.brand : '#fff'} />
+      ) : (
+        <>
+          {icon ? <SymbolView name={icon} tintColor={subtle ? colors.brand : '#fff'} size={16} /> : null}
+          <Text style={subtle ? styles.subtleButtonLabel : styles.primaryButtonLabel}>{label}</Text>
+        </>
+      )}
+    </Pressable>
+  );
+}
+
+function HistoryStatus({ status }: { status: string }) {
+  const redeemed = status === 'redeemed';
+
+  return (
+    <View style={styles.statusPill}>
+      <SymbolView
+        name={redeemed ? 'checkmark.circle.fill' : 'xmark.circle.fill'}
+        tintColor={redeemed ? colors.success : colors.danger}
+        size={14}
+      />
+      <Text style={[styles.statusText, redeemed ? styles.positiveText : styles.negativeText]}>
+        {status.toUpperCase()}
+      </Text>
+    </View>
   );
 }
 
 export default function RequesterScreen() {
   const { hasLoadedRequest, markRequestLoaded } = useTabCache();
+  const router = useRouter();
+  const params = useLocalSearchParams<{ autoGenerate?: string }>();
+
   const [weeklyAllowance, setWeeklyAllowance] = useState(0);
   const [remainingAllowance, setRemainingAllowance] = useState(0);
   const [daysUntilReset, setDaysUntilReset] = useState(0);
@@ -102,80 +178,92 @@ export default function RequesterScreen() {
   const [loading, setLoading] = useState(!hasLoadedRequest);
   const [generating, setGenerating] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
-  const [timeRemaining, setTimeRemaining] = useState<string>('');
+  const [timeRemaining, setTimeRemaining] = useState('');
   const [refreshingCode, setRefreshingCode] = useState(false);
   const refreshingCodeRef = useRef(false);
-  const [isRefreshingData, setIsRefreshingData] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [redemptionInfo, setRedemptionInfo] = useState<{
     amount: number;
     accountName?: string;
   } | null>(null);
   const [poolExhaustedMessage, setPoolExhaustedMessage] = useState<string | null>(null);
+
   const redeemedRail = inferCheckoutRail(redemptionInfo?.accountName);
   const activeCheckoutRail: CheckoutRail = currentCode?.recommendedRail ?? 'points-or-bucks';
   const checkoutInstruction =
-    activeCheckoutRail === 'flexi-dollars' ? 'Use Flexi Dollars' : 'Using Slugpoints';
+    activeCheckoutRail === 'flexi-dollars' ? 'Use Flexi Dollars' : 'Use Points or Bucks';
   const checkoutDetail =
     activeCheckoutRail === 'flexi-dollars'
       ? 'This claim is currently pulling from the donor Flexi balance.'
-      : 'This claim is currently pulling from donor Slug Points / Banana Bucks.';
+      : 'This claim is currently pulling from donor Slug Points or Banana Bucks.';
   const donorCourtesyLabel = currentCode?.donorDisplayName
     ? `Courtesy of ${currentCode.donorDisplayName}`
     : 'Courtesy of a SlugSwap donor';
 
   useEffect(() => {
     if (hasLoadedRequest) return;
-    loadUserAndAllowance();
-  }, []);
+    void loadUserAndAllowance();
+  }, [hasLoadedRequest]);
 
   useEffect(() => {
-    if (currentCode) {
-      const interval = setInterval(async () => {
-        const now = new Date();
-        const expiresAt = new Date(currentCode.expiresAt);
-        const diff = expiresAt.getTime() - now.getTime();
+    if (params.autoGenerate !== '1') return;
+    if (loading || generating || !userId || currentCode) return;
 
-        if (diff <= 0) {
-          // One final redemption check before marking as expired
-          if (userId) {
-            try {
-              const result = await checkRedemption(userId, currentCode.id);
-              if (result.redeemed) {
-                setCurrentCode(null);
-                setTimeRemaining('');
-                setRedemptionInfo({
-                  amount: result.amount ?? parseFloat(String(currentCode.amount)),
-                  accountName: result.accountName,
-                });
-                void loadUserAndAllowance();
-                return;
-              }
-            } catch (error) {
-              console.warn('Final redemption check failed:', error);
+    void handleGenerateCode().finally(() => {
+      router.replace('/(tabs)/(request)');
+    });
+  }, [currentCode, generating, loading, params.autoGenerate, router, userId]);
+
+  useEffect(() => {
+    if (!currentCode) return;
+
+    const interval = setInterval(async () => {
+      const now = new Date();
+      const expiresAt = new Date(currentCode.expiresAt);
+      const diff = expiresAt.getTime() - now.getTime();
+
+      if (diff <= 0) {
+        if (userId) {
+          try {
+            const result = await checkRedemption(userId, currentCode.id);
+            if (result.redeemed) {
+              setCurrentCode(null);
+              setTimeRemaining('');
+              setRedemptionInfo({
+                amount: result.amount ?? parseFloat(String(currentCode.amount)),
+                accountName: result.accountName,
+              });
+              void loadUserAndAllowance();
+              return;
             }
+          } catch (error) {
+            console.warn('Final redemption check failed:', error);
           }
-          setCurrentCode(null);
-          setTimeRemaining('');
-          loadUserAndAllowance();
-        } else {
-          const minutes = Math.floor(diff / 60000);
-          const seconds = Math.floor((diff % 60000) / 1000);
-          setTimeRemaining(`${minutes}:${seconds.toString().padStart(2, '0')}`);
         }
-      }, 1000);
 
-      return () => clearInterval(interval);
-    }
-  }, [currentCode]);
+        setCurrentCode(null);
+        setTimeRemaining('');
+        void loadUserAndAllowance();
+        return;
+      }
+
+      const minutes = Math.floor(diff / 60000);
+      const seconds = Math.floor((diff % 60000) / 1000);
+      setTimeRemaining(`${minutes}:${seconds.toString().padStart(2, '0')}`);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [currentCode, userId]);
 
   useEffect(() => {
     if (!currentCode || !userId) return;
 
     const interval = setInterval(async () => {
       if (refreshingCodeRef.current) return;
+
       refreshingCodeRef.current = true;
       setRefreshingCode(true);
+
       try {
         const result = await refreshClaimCode(userId, currentCode.id);
         if (result.claimCode.status === 'redeemed') {
@@ -188,14 +276,17 @@ export default function RequesterScreen() {
           void loadUserAndAllowance();
           return;
         }
+
         setCurrentCode({
           ...result.claimCode,
-          recommendedRail: result.claimCode.recommendedRail ?? currentCode.recommendedRail ?? 'points-or-bucks',
+          recommendedRail:
+            result.claimCode.recommendedRail ?? currentCode.recommendedRail ?? 'points-or-bucks',
           donorDisplayName: result.claimCode.donorDisplayName ?? currentCode.donorDisplayName ?? null,
         });
       } catch (error: any) {
         const message = error?.message || 'Failed to refresh claim code';
         console.warn('Claim code refresh failed:', message);
+
         if (typeof message === 'string' && (message.includes('expired') || message.includes('not active'))) {
           setCurrentCode(null);
           setTimeRemaining('');
@@ -212,7 +303,10 @@ export default function RequesterScreen() {
 
   async function loadUserAndAllowance() {
     try {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
       if (!user) {
         Alert.alert('Error', 'Please sign in first');
         return;
@@ -235,7 +329,6 @@ export default function RequesterScreen() {
       Alert.alert('Error', 'Failed to load your allowance data');
     } finally {
       setLoading(false);
-      setIsRefreshingData(false);
       markRequestLoaded();
     }
   }
@@ -272,6 +365,7 @@ export default function RequesterScreen() {
         setPoolExhaustedMessage(POOL_EXHAUSTED_MESSAGE);
         return;
       }
+
       console.error('Error generating code:', error);
       setPoolExhaustedMessage(null);
       Alert.alert('Error', error.message || 'Failed to generate claim code');
@@ -282,275 +376,554 @@ export default function RequesterScreen() {
 
   if (loading) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ActivityIndicator size="large" color={uiColor('systemBlue')} />
+      <View style={styles.loadingScreen}>
+        <ActivityIndicator size="large" color={colors.brand} />
       </View>
     );
   }
 
   return (
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={{ padding: 16, gap: 16, paddingBottom: 32 }}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-      >
-        {/* Weekly Allowance Card */}
-        <Card>
-          <Text style={{ fontSize: 17, fontWeight: '600', color: uiColor('label'), marginBottom: 16 }}>
-            Weekly Allowance
-          </Text>
-          <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-            <View>
-              <Text selectable style={{ fontSize: 48, fontWeight: 'bold', color: uiColor('systemBlue'), fontVariant: ['tabular-nums'] }}>
-                {remainingAllowance}
-              </Text>
-              <Text style={{ fontSize: 14, color: uiColor('secondaryLabel') }}>points remaining</Text>
-            </View>
-            <View style={{ alignItems: 'flex-end' }}>
-              <Text style={{ fontSize: 18, color: uiColor('tertiaryLabel'), fontVariant: ['tabular-nums'] }}>
-                of {weeklyAllowance}
-              </Text>
-            </View>
+    <ScrollView
+      style={styles.screen}
+      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor={colors.brand}
+          colors={[colors.brand]}
+        />
+      }
+    >
+      <View style={styles.passCard}>
+        <View style={styles.passNotch} />
+        <Text style={styles.passTitle}>UCSC Dining Services</Text>
+        <View style={styles.passBand} />
+
+        <View style={styles.passInner}>
+          <View style={styles.passPortrait}>
+            <SymbolView name="person.crop.circle.badge.questionmark" tintColor="rgba(255,255,255,0.85)" size={120} />
           </View>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-            <SymbolView name="clock" tintColor={uiColor('tertiaryLabel')} size={12} />
-            <Text style={{ fontSize: 13, color: uiColor('tertiaryLabel') }}>
+          <View style={styles.passNameBand}>
+            <Text style={styles.passName}>{currentCode ? 'Scan Card' : 'Requester Pass'}</Text>
+          </View>
+
+          {currentCode ? (
+            <>
+              <View style={styles.barcodeWrap}>
+                <PDF417Barcode value={currentCode.code} width={280} height={100} />
+              </View>
+              <Text selectable style={styles.codeText}>
+                {currentCode.code}
+              </Text>
+              <View style={styles.inlineHeroMeta}>
+                <View style={styles.inlineHeroPill}>
+                  <SymbolView name="checkmark.circle.fill" tintColor="#fff" size={13} />
+                  <Text style={styles.inlineHeroPillLabel}>{checkoutInstruction}</Text>
+                </View>
+                <Text style={styles.heroHint}>{donorCourtesyLabel}</Text>
+                <Text style={styles.heroHint}>{checkoutDetail}</Text>
+              </View>
+              <View style={styles.expirationRow}>
+                <SymbolView name="clock.badge.exclamationmark" tintColor="#fff" size={14} />
+                <Text style={styles.expirationText}>Expires in {timeRemaining}</Text>
+              </View>
+              <Text style={styles.refreshText}>Refreshing every 5s{refreshingCode ? ' ...' : ''}</Text>
+            </>
+          ) : (
+            <View style={styles.heroSummary}>
+              <Text style={styles.heroMetric}>{remainingAllowance}</Text>
+              <Text style={styles.heroMetricLabel}>points remaining this week</Text>
+              <Text style={styles.heroHint}>Every claim generates a short-lived scan code.</Text>
+
+              {poolExhaustedMessage && remainingAllowance >= DEFAULT_CLAIM_AMOUNT ? (
+                <View style={styles.poolNote}>
+                  <SymbolView name="exclamationmark.circle.fill" tintColor="#fff" size={16} />
+                  <Text style={styles.poolNoteText}>{POOL_EXHAUSTED_MESSAGE}</Text>
+                </View>
+              ) : null}
+
+              <PrimaryAction
+                label={poolExhaustedMessage ? 'Try Again' : 'Generate Claim Code'}
+                onPress={() => {
+                  void handleGenerateCode();
+                }}
+                loading={generating}
+                disabled={remainingAllowance === 0}
+                icon="qrcode"
+                subtle
+              />
+            </View>
+          )}
+        </View>
+      </View>
+
+      <SectionCard>
+        <SectionHeader
+          icon="banknote"
+          title="Allowance"
+          detail="Your weekly requester balance and reset timing"
+        />
+
+        <View style={styles.allowanceRow}>
+          <View>
+            <Text style={styles.allowanceValue}>{remainingAllowance}</Text>
+            <Text style={styles.allowanceLabel}>points remaining</Text>
+          </View>
+          <View style={styles.allowanceRight}>
+            <Text style={styles.allowanceContext}>of {weeklyAllowance}</Text>
+            <Text style={styles.allowanceReset}>
               Resets in {daysUntilReset} {daysUntilReset === 1 ? 'day' : 'days'}
             </Text>
           </View>
-        </Card>
-
-        {/* Redemption Success */}
-        {redemptionInfo && (
-          <Card>
-            <View style={{ alignItems: 'center', gap: 12 }}>
-              <SymbolView name="checkmark.circle.fill" tintColor={uiColor('systemGreen')} size={48} />
-              <Text style={{ fontSize: 22, fontWeight: '700', color: uiColor('systemGreen') }}>
-                Redeemed!
-              </Text>
-              <Text style={{ fontSize: 17, color: uiColor('label'), fontVariant: ['tabular-nums'] }}>
-                {redemptionInfo.amount} points used
-              </Text>
-              {redemptionInfo.accountName && (
-                <Text style={{ fontSize: 14, color: uiColor('secondaryLabel') }}>
-                  from {redemptionInfo.accountName}
-                </Text>
-              )}
-              {redeemedRail && (
-                <View style={{
-                  marginTop: 4,
-                  backgroundColor: uiColor('tertiarySystemFill'),
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  paddingVertical: 8,
-                  paddingHorizontal: 10,
-                }}>
-                  <Text style={{ fontSize: 13, color: uiColor('label'), fontWeight: '600' }}>
-                    Cashier selection: {redeemedRail === 'flexi-dollars' ? 'Flexi Dollars' : 'Points or Bucks'}
-                  </Text>
-                </View>
-              )}
-              <Pressable
-                onPress={() => setRedemptionInfo(null)}
-                style={({ pressed }) => ({
-                  marginTop: 8,
-                  paddingVertical: 10,
-                  paddingHorizontal: 24,
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  backgroundColor: uiColor('systemGreen'),
-                  opacity: pressed ? 0.7 : 1,
-                })}
-              >
-                <Text style={{ color: '#fff', fontSize: 15, fontWeight: '600' }}>Done</Text>
-              </Pressable>
-            </View>
-          </Card>
-        )}
-
-        {/* Active Code or Generate Button */}
-        {!redemptionInfo && currentCode ? (
-          <Card>
-            <Text style={{ fontSize: 17, fontWeight: '600', color: uiColor('label'), marginBottom: 16 }}>
-              Your Claim Code
-            </Text>
-            <View style={{
-              backgroundColor: uiColor('systemBackground'),
-              padding: 16,
-              borderRadius: 12,
-              borderCurve: 'continuous',
-              alignItems: 'center',
-              marginBottom: 12,
-              borderWidth: 0.5,
-              borderColor: uiColor('separator'),
-            }}>
-              <PDF417Barcode value={currentCode.code} width={280} height={100} />
-            </View>
-            <Text selectable style={{
-              fontSize: 14,
-              fontWeight: '600',
-              letterSpacing: 2,
-              color: uiColor('secondaryLabel'),
-              marginBottom: 12,
-              fontFamily: 'Menlo',
-            }}>
-              {currentCode.code}
-            </Text>
-            <View style={{
-              width: '100%',
-              gap: 8,
-              marginBottom: 14,
-              padding: 14,
-              borderRadius: 12,
-              borderCurve: 'continuous',
-              backgroundColor: uiColor('tertiarySystemFill'),
-            }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <SymbolView name="megaphone.fill" tintColor={uiColor('systemBlue')} size={14} />
-                <Text style={{ fontSize: 13, fontWeight: '600', color: uiColor('secondaryLabel') }}>
-                  At checkout, say:
-                </Text>
-              </View>
-              <View style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                alignSelf: 'flex-start',
-                gap: 6,
-                paddingVertical: 9,
-                paddingHorizontal: 12,
-                borderRadius: 999,
-                borderCurve: 'continuous',
-                backgroundColor: uiColor('systemBlue'),
-              }}>
-                <SymbolView name="checkmark.circle.fill" tintColor="#fff" size={13} />
-                <Text style={{ fontSize: 14, fontWeight: '700', color: '#fff' }}>
-                  {checkoutInstruction}
-                </Text>
-              </View>
-              <Text style={{ fontSize: 12, color: uiColor('secondaryLabel') }}>
-                {checkoutDetail}
-              </Text>
-              <Text selectable style={{ fontSize: 12, color: uiColor('tertiaryLabel') }}>
-                {donorCourtesyLabel}
-              </Text>
-            </View>
-            <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 4, marginBottom: 12 }}>
-              <SymbolView name="clock.badge.exclamationmark" tintColor={uiColor('systemRed')} size={14} />
-              <Text style={{ fontSize: 14, color: uiColor('systemRed'), fontVariant: ['tabular-nums'] }}>
-                Expires in {timeRemaining}
-              </Text>
-            </View>
-            <Text style={{ textAlign: 'center', fontSize: 13, color: uiColor('secondaryLabel') }}>
-              Show this code at the dining hall.
-            </Text>
-            <Text style={{ marginTop: 8, textAlign: 'center', fontSize: 12, color: uiColor('tertiaryLabel') }}>
-              Refreshing every 5s{refreshingCode ? ' ...' : ''}
-            </Text>
-          </Card>
-        ) : !redemptionInfo && poolExhaustedMessage && remainingAllowance >= DEFAULT_CLAIM_AMOUNT ? (
-          <Card>
-            <View style={{ alignItems: 'center', gap: 12 }}>
-              <SymbolView name="exclamationmark.circle.fill" tintColor={uiColor('systemOrange')} size={40} />
-              <Text style={{ fontSize: 22, fontWeight: '700', color: uiColor('label'), textAlign: 'center' }}>
-                {POOL_EXHAUSTED_TITLE}
-              </Text>
-              <Text style={{ fontSize: 15, color: uiColor('secondaryLabel'), textAlign: 'center', lineHeight: 22 }}>
-                {poolExhaustedMessage}
-              </Text>
-              <Pressable
-                onPress={handleGenerateCode}
-                disabled={generating}
-                style={({ pressed }) => ({
-                  marginTop: 4,
-                  paddingVertical: 12,
-                  paddingHorizontal: 24,
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  backgroundColor: uiColor('systemBlue'),
-                  opacity: pressed || generating ? 0.7 : 1,
-                })}
-              >
-                {generating ? (
-                  <ActivityIndicator color="#fff" />
-                ) : (
-                  <Text style={{ color: '#fff', fontSize: 15, fontWeight: '600' }}>Try Again</Text>
-                )}
-              </Pressable>
-            </View>
-          </Card>
-        ) : !redemptionInfo ? (
-          <Pressable
-            onPress={handleGenerateCode}
-            disabled={remainingAllowance === 0 || generating}
-            style={({ pressed }) => ({
-              alignItems: 'center',
-              justifyContent: 'center',
-              flexDirection: 'row',
-              gap: 8,
-              paddingVertical: 18,
-              borderRadius: 14,
-              borderCurve: 'continuous',
-              backgroundColor: uiColor('systemBlue'),
-              opacity: pressed ? 0.7 : (remainingAllowance === 0 || generating) ? 0.5 : 1,
-            })}
-          >
-            {generating ? (
-              <ActivityIndicator color="#fff" />
-            ) : (
-              <>
-                <SymbolView name="qrcode" tintColor="#fff" size={20} />
-                <Text style={{ color: '#fff', fontSize: 17, fontWeight: '600' }}>Generate Claim Code</Text>
-              </>
-            )}
-          </Pressable>
-        ) : null}
-
-        {/* Recent Claims */}
-        <View style={{ gap: 12 }}>
-          <Text style={{ fontSize: 20, fontWeight: '600', color: uiColor('label') }}>
-            Recent Claims
-          </Text>
-          {claimHistory.length === 0 ? (
-            <View style={{ alignItems: 'center', paddingVertical: 32 }}>
-              <SymbolView name="tray" tintColor={uiColor('tertiaryLabel')} size={32} />
-              <Text style={{ color: uiColor('tertiaryLabel'), marginTop: 8, fontSize: 15 }}>No claims yet</Text>
-            </View>
-          ) : (
-            claimHistory.map((claim) => (
-              <Card key={claim.id} style={{ padding: 16 }}>
-                <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <View style={{ flex: 1, marginRight: 12 }}>
-                    <Text selectable style={{ fontSize: 14, fontWeight: '600', color: uiColor('label'), marginBottom: 4, fontFamily: 'Menlo' }}>
-                      {claim.code}
-                    </Text>
-                    <Text style={{ fontSize: 13, color: uiColor('tertiaryLabel') }}>
-                      {new Date(claim.createdAt).toLocaleDateString()}
-                    </Text>
-                  </View>
-                  <View style={{ alignItems: 'flex-end', gap: 4 }}>
-                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                      <SymbolView
-                        name={claim.status === 'redeemed' ? 'checkmark.circle.fill' : 'xmark.circle.fill'}
-                        tintColor={claim.status === 'redeemed' ? uiColor('systemGreen') : uiColor('systemRed')}
-                        size={14}
-                      />
-                      <Text style={{
-                        fontSize: 12,
-                        fontWeight: '600',
-                        color: claim.status === 'redeemed' ? uiColor('systemGreen') : uiColor('systemRed'),
-                      }}>
-                        {claim.status.toUpperCase()}
-                      </Text>
-                    </View>
-                    <Text style={{ fontSize: 13, color: uiColor('secondaryLabel'), fontVariant: ['tabular-nums'] }}>
-                      {claim.amount} pts
-                    </Text>
-                  </View>
-                </View>
-              </Card>
-            ))
-          )}
         </View>
-      </ScrollView>
+
+        {redemptionInfo ? (
+          <View style={styles.redeemedCard}>
+            <View style={styles.redeemedHeader}>
+              <SymbolView name="checkmark.circle.fill" tintColor={colors.success} size={28} />
+              <Text style={styles.redeemedTitle}>Redeemed</Text>
+            </View>
+            <Text style={styles.redeemedAmount}>{redemptionInfo.amount} points used</Text>
+            {redemptionInfo.accountName ? (
+              <Text style={styles.redeemedMeta}>from {redemptionInfo.accountName}</Text>
+            ) : null}
+            {redeemedRail ? (
+              <Text style={styles.redeemedMeta}>
+                Cashier selection: {redeemedRail === 'flexi-dollars' ? 'Flexi Dollars' : 'Points or Bucks'}
+              </Text>
+            ) : null}
+            <PrimaryAction
+              label="Done"
+              onPress={() => setRedemptionInfo(null)}
+              subtle
+            />
+          </View>
+        ) : null}
+      </SectionCard>
+
+      <SectionCard>
+        <SectionHeader
+          icon="clock.arrow.circlepath"
+          title="Recent Claims"
+          detail="Your latest scan attempts and outcomes"
+        />
+
+        {claimHistory.length === 0 ? (
+          <View style={styles.emptyState}>
+            <SymbolView name="tray" tintColor={colors.textSoft} size={30} />
+            <Text style={styles.emptyStateTitle}>No claims yet</Text>
+            <Text style={styles.emptyStateCopy}>When you generate a claim, it will show up here.</Text>
+          </View>
+        ) : (
+          <View style={styles.historyList}>
+            {claimHistory.map((claim) => (
+              <View key={claim.id} style={styles.historyRow}>
+                <View style={styles.historyLeft}>
+                  <Text selectable style={styles.historyCode}>
+                    {claim.code}
+                  </Text>
+                  <Text style={styles.historyMeta}>{new Date(claim.createdAt).toLocaleDateString()}</Text>
+                </View>
+                <View style={styles.historyRight}>
+                  <HistoryStatus status={claim.status} />
+                  <Text style={styles.historyAmount}>{claim.amount} pts</Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+      </SectionCard>
+    </ScrollView>
   );
 }
+
+const colors = stealthTheme.colors;
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.canvas,
+  },
+  content: {
+    padding: 18,
+    gap: 18,
+    paddingBottom: 36,
+  },
+  loadingScreen: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.canvas,
+  },
+  passCard: {
+    borderRadius: 26,
+    overflow: 'hidden',
+    backgroundColor: colors.brand,
+    borderWidth: 1,
+    borderColor: colors.brandDark,
+    ...cardShadow('hero'),
+  },
+  passNotch: {
+    position: 'absolute',
+    top: 0,
+    left: '40%',
+    width: 80,
+    height: 80,
+    backgroundColor: colors.brandDark,
+  },
+  passTitle: {
+    paddingTop: 24,
+    paddingHorizontal: 20,
+    paddingBottom: 18,
+    textAlign: 'center',
+    color: '#ffffff',
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: '500',
+  },
+  passBand: {
+    height: 100,
+    backgroundColor: colors.brandDark,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: colors.brandDeeper,
+  },
+  passInner: {
+    paddingHorizontal: 22,
+    paddingTop: 14,
+    paddingBottom: 20,
+    alignItems: 'center',
+  },
+  passPortrait: {
+    width: '100%',
+    minHeight: 300,
+    borderRadius: 24,
+    backgroundColor: '#d8d8d8',
+    marginTop: -84,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.7)',
+  },
+  passNameBand: {
+    width: '100%',
+    backgroundColor: 'rgba(97, 105, 112, 0.6)',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    marginTop: -80,
+    borderBottomLeftRadius: 24,
+    borderBottomRightRadius: 24,
+  },
+  passName: {
+    color: '#ffffff',
+    fontSize: 21,
+    lineHeight: 26,
+    fontWeight: '500',
+  },
+  barcodeWrap: {
+    width: '100%',
+    marginTop: 22,
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderRadius: 18,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+  },
+  codeText: {
+    marginTop: 14,
+    color: 'rgba(255,255,255,0.9)',
+    fontSize: 13,
+    lineHeight: 18,
+    letterSpacing: 2,
+    fontFamily: monoFontFamily,
+    fontWeight: '700',
+  },
+  inlineHeroMeta: {
+    marginTop: 14,
+    alignItems: 'center',
+    gap: 8,
+  },
+  inlineHeroPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: colors.brandDark,
+  },
+  inlineHeroPillLabel: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  expirationRow: {
+    marginTop: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  expirationText: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  refreshText: {
+    marginTop: 8,
+    color: 'rgba(255,255,255,0.76)',
+    fontSize: 12,
+    lineHeight: 16,
+  },
+  heroSummary: {
+    width: '100%',
+    alignItems: 'center',
+    gap: 8,
+    paddingTop: 22,
+  },
+  heroMetric: {
+    color: '#ffffff',
+    fontSize: 50,
+    lineHeight: 54,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  heroMetricLabel: {
+    color: 'rgba(255,255,255,0.9)',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  heroHint: {
+    textAlign: 'center',
+    color: 'rgba(255,255,255,0.76)',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  poolNote: {
+    width: '100%',
+    marginTop: 8,
+    borderRadius: 16,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: 'rgba(8, 34, 54, 0.22)',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  poolNoteText: {
+    flex: 1,
+    color: '#ffffff',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  sectionCard: {
+    borderRadius: 24,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingTop: 14,
+    paddingBottom: 16,
+    ...cardShadow(),
+  },
+  sectionHeader: {
+    paddingHorizontal: 18,
+    paddingBottom: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.surfaceStrong,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  sectionIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  sectionHeaderText: {
+    flex: 1,
+    gap: 2,
+  },
+  sectionTitle: {
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  sectionDetail: {
+    ...typeScale.caption,
+    color: colors.textMuted,
+  },
+  allowanceRow: {
+    paddingHorizontal: 18,
+    paddingTop: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+  },
+  allowanceValue: {
+    color: colors.brand,
+    fontSize: 44,
+    lineHeight: 48,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  allowanceLabel: {
+    marginTop: 2,
+    ...typeScale.caption,
+    color: colors.textMuted,
+  },
+  allowanceRight: {
+    alignItems: 'flex-end',
+    gap: 4,
+  },
+  allowanceContext: {
+    fontSize: 18,
+    lineHeight: 22,
+    fontWeight: '600',
+    color: colors.textSoft,
+    fontVariant: ['tabular-nums'],
+  },
+  allowanceReset: {
+    ...typeScale.caption,
+    color: colors.textMuted,
+  },
+  redeemedCard: {
+    marginHorizontal: 18,
+    marginTop: 16,
+    borderRadius: 18,
+    padding: 16,
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+    gap: 8,
+  },
+  redeemedHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  redeemedTitle: {
+    color: colors.success,
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  redeemedAmount: {
+    color: colors.text,
+    fontSize: 18,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  redeemedMeta: {
+    ...typeScale.caption,
+    color: colors.textMuted,
+  },
+  primaryButton: {
+    width: '100%',
+    minHeight: 52,
+    marginTop: 12,
+    borderRadius: 16,
+    backgroundColor: colors.brand,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  primaryButtonLabel: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  subtleButton: {
+    width: '100%',
+    minHeight: 52,
+    marginTop: 10,
+    borderRadius: 16,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: '#d1dbed',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  subtleButtonLabel: {
+    color: colors.brand,
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  emptyState: {
+    alignItems: 'center',
+    paddingHorizontal: 18,
+    paddingVertical: 28,
+    gap: 10,
+  },
+  emptyStateTitle: {
+    color: colors.text,
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  emptyStateCopy: {
+    textAlign: 'center',
+    ...typeScale.body,
+    color: colors.textMuted,
+  },
+  historyList: {
+    paddingTop: 10,
+  },
+  historyRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 16,
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    borderTopWidth: 1,
+    borderTopColor: colors.surfaceStrong,
+  },
+  historyLeft: {
+    flex: 1,
+    gap: 4,
+  },
+  historyCode: {
+    color: colors.text,
+    fontSize: 14,
+    fontWeight: '700',
+    fontFamily: monoFontFamily,
+  },
+  historyMeta: {
+    ...typeScale.caption,
+    color: colors.textSoft,
+  },
+  historyRight: {
+    alignItems: 'flex-end',
+    gap: 6,
+  },
+  statusPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  statusText: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  positiveText: {
+    color: colors.success,
+  },
+  negativeText: {
+    color: colors.danger,
+  },
+  historyAmount: {
+    color: colors.textMuted,
+    fontSize: 13,
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+  },
+});

--- a/apps/mobile/app/(tabs)/(request)/index.tsx
+++ b/apps/mobile/app/(tabs)/(request)/index.tsx
@@ -225,7 +225,7 @@ export default function RequesterScreen() {
       if (diff <= 0) {
         if (userId) {
           try {
-            const result = await checkRedemption(userId, currentCode.id);
+            const result = await checkRedemption(currentCode.id);
             if (result.redeemed) {
               setCurrentCode(null);
               setTimeRemaining('');
@@ -265,7 +265,7 @@ export default function RequesterScreen() {
       setRefreshingCode(true);
 
       try {
-        const result = await refreshClaimCode(userId, currentCode.id);
+        const result = await refreshClaimCode(currentCode.id);
         if (result.claimCode.status === 'redeemed') {
           setCurrentCode(null);
           setTimeRemaining('');
@@ -322,7 +322,7 @@ export default function RequesterScreen() {
         setPoolExhaustedMessage(null);
       }
 
-      const historyData = await getClaimHistory(user.id);
+      const historyData = await getClaimHistory();
       setClaimHistory(historyData.claims);
     } catch (error) {
       console.error('Error loading allowance:', error);
@@ -350,7 +350,7 @@ export default function RequesterScreen() {
 
     setGenerating(true);
     try {
-      const result = await generateClaimCode(userId, DEFAULT_CLAIM_AMOUNT);
+      const result = await generateClaimCode(DEFAULT_CLAIM_AMOUNT);
       setPoolExhaustedMessage(null);
       setCurrentCode({
         ...result.claimCode,

--- a/apps/mobile/app/(tabs)/(share)/index.tsx
+++ b/apps/mobile/app/(tabs)/(share)/index.tsx
@@ -527,16 +527,9 @@ export default function DonorScreen() {
     );
   }
 
-  const donorName = userDisplayName;
   const handleHeroAction = () => {
     if (isGetLinked) {
-      router.push({
-        pathname: '/scan-card',
-        params: {
-          userId: userId ?? undefined,
-          displayName: donorName,
-        },
-      });
+      router.push('/scan-card');
       return;
     }
 
@@ -570,7 +563,7 @@ export default function DonorScreen() {
             </View>
           </View>
           <View style={styles.passContent}>
-            <Text style={styles.passName}>{donorName}</Text>
+            <Text style={styles.passName}>{userDisplayName}</Text>
 
             <Pressable
               onPress={handleHeroAction}

--- a/apps/mobile/app/(tabs)/(share)/index.tsx
+++ b/apps/mobile/app/(tabs)/(share)/index.tsx
@@ -530,7 +530,13 @@ export default function DonorScreen() {
   const donorName = userDisplayName;
   const handleHeroAction = () => {
     if (isGetLinked) {
-      router.push('/scan-card');
+      router.push({
+        pathname: '/scan-card',
+        params: {
+          userId: userId ?? undefined,
+          displayName: donorName,
+        },
+      });
       return;
     }
 

--- a/apps/mobile/app/(tabs)/(share)/index.tsx
+++ b/apps/mobile/app/(tabs)/(share)/index.tsx
@@ -1,21 +1,50 @@
-import { View, Text, TextInput, Pressable, ActivityIndicator, Alert, ScrollView, RefreshControl, Platform } from 'react-native';
-import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
-import { BlurView } from 'expo-blur';
-import { SymbolView } from 'expo-symbols';
-import { useState, useEffect, useCallback } from 'react';
-import { useAuth } from '../../../../../lib/auth-context';
-import { supabase } from '../../../../../lib/supabase';
-import { setDonation, getDonorImpact, pauseDonation, getGetAccounts, getGetLinkStatus, getGetLoginUrl, linkGetAccount, unlinkGetAccount, type DonorImpact } from '../../../../../lib/api';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { SymbolView, type SymbolViewProps } from 'expo-symbols';
 import * as WebBrowser from 'expo-web-browser';
-import { useTabCache, type GetAccountBalance, type ShareTabSnapshot } from '../../../../../lib/tab-cache-context';
 import { useFocusEffect } from 'expo-router';
-import { uiColor } from '../../../lib/ui-color';
 
-const UCSC_TRACKED_BALANCE_ACCOUNTS = new Set([
-  'flexi dollars',
-  'banana bucks',
-  'slug points',
-]);
+import { useAuth } from '../../../../../lib/auth-context';
+import {
+  getDonorImpact,
+  getGetAccounts,
+  getGetLinkStatus,
+  getGetLoginUrl,
+  linkGetAccount,
+  pauseDonation,
+  setDonation,
+  unlinkGetAccount,
+  type DonorImpact,
+} from '../../../../../lib/api';
+import { supabase } from '../../../../../lib/supabase';
+import {
+  useTabCache,
+  type GetAccountBalance,
+  type ShareTabSnapshot,
+} from '../../../../../lib/tab-cache-context';
+import {
+  buttonOpacity,
+  cardShadow,
+  stealthTheme,
+  typeScale,
+} from '../../../lib/stealth-theme';
+import { useRouter } from 'expo-router';
+import { GetMobileTabBar } from '../../../components/GetMobileTabBar';
+
+const UCSC_TRACKED_BALANCE_ACCOUNTS = new Set(['flexi dollars', 'banana bucks', 'slug points']);
 
 const EMPTY_IMPACT: DonorImpact = {
   isActive: false,
@@ -57,33 +86,145 @@ function normalizeDonorImpact(raw: Partial<DonorImpact> | null | undefined): Don
   };
 }
 
-function Card({ children, style }: { children: React.ReactNode; style?: any }) {
-  if (isLiquidGlassAvailable()) {
-    return (
-      <GlassView style={[{ borderRadius: 16, padding: 20 }, style]}>
-        {children}
-      </GlassView>
-    );
-  }
+function formatNameFromEmail(email: string | null): string {
+  if (!email) return 'SlugSwap Donor';
+
+  return email
+    .split('@')[0]
+    .split(/[._-]/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+function SectionCard({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+}) {
+  return <View style={[styles.sectionCard, style]}>{children}</View>;
+}
+
+function SectionHeader({
+  icon,
+  title,
+  detail,
+}: {
+  icon: SymbolViewProps['name'];
+  title: string;
+  detail?: string;
+}) {
   return (
-    <BlurView
-      tint="systemMaterial"
-      intensity={80}
-      style={[{
-        borderRadius: 16,
-        padding: 20,
-        overflow: 'hidden',
-      }, style]}
+    <View style={styles.sectionHeader}>
+      <View style={styles.sectionHeaderLeft}>
+        <View style={styles.sectionIcon}>
+          <SymbolView name={icon} tintColor={colors.textSoft} size={18} />
+        </View>
+        <View style={styles.sectionHeaderText}>
+          <Text style={styles.sectionTitle}>{title}</Text>
+          {detail ? <Text style={styles.sectionDetail}>{detail}</Text> : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function MetricTile({
+  label,
+  value,
+  emphasized = false,
+  style,
+}: {
+  label: string;
+  value: string;
+  emphasized?: boolean;
+  style?: StyleProp<ViewStyle>;
+}) {
+  return (
+    <View style={[styles.metricTile, emphasized ? styles.metricTileAccent : null, style]}>
+      <Text style={styles.metricLabel}>{label}</Text>
+      <Text style={[styles.metricValue, emphasized ? styles.metricValueAccent : null]}>{value}</Text>
+    </View>
+  );
+}
+
+function SecondaryButton({
+  label,
+  onPress,
+  icon,
+  destructive = false,
+  disabled = false,
+  loading = false,
+}: {
+  label: string;
+  onPress: () => void;
+  icon?: SymbolViewProps['name'];
+  destructive?: boolean;
+  disabled?: boolean;
+  loading?: boolean;
+}) {
+  const tintColor = destructive ? colors.danger : colors.brand;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled || loading}
+      style={({ pressed }) => [
+        styles.secondaryButton,
+        { opacity: buttonOpacity(pressed, disabled || loading) },
+      ]}
     >
-      {children}
-    </BlurView>
+      {loading ? (
+        <ActivityIndicator size="small" color={tintColor} />
+      ) : (
+        <>
+          {icon ? <SymbolView name={icon} tintColor={tintColor} size={14} /> : null}
+          <Text style={[styles.secondaryButtonLabel, destructive ? styles.destructiveLabel : null]}>
+            {label}
+          </Text>
+        </>
+      )}
+    </Pressable>
+  );
+}
+
+function PrimaryButton({
+  label,
+  onPress,
+  disabled = false,
+  loading = false,
+}: {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled || loading}
+      style={({ pressed }) => [
+        styles.primaryButton,
+        { opacity: buttonOpacity(pressed, disabled || loading) },
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator color="#fff" />
+      ) : (
+        <Text style={styles.primaryButtonLabel}>{label}</Text>
+      )}
+    </Pressable>
   );
 }
 
 export default function DonorScreen() {
   const { signOut } = useAuth();
+  const router = useRouter();
   const { hasLoadedShare, markShareLoaded, shareSnapshot, setShareSnapshot } = useTabCache();
   const hasShareSnapshot = !!shareSnapshot;
+
   const [weeklyAmount, setWeeklyAmount] = useState(shareSnapshot?.weeklyAmount ?? '');
   const [isActive, setIsActive] = useState(shareSnapshot?.isActive ?? false);
   const [loading, setLoading] = useState(!shareSnapshot);
@@ -91,6 +232,9 @@ export default function DonorScreen() {
   const [impact, setImpact] = useState<DonorImpact>(shareSnapshot?.impact ?? EMPTY_IMPACT);
   const [userId, setUserId] = useState<string | null>(shareSnapshot?.userId ?? null);
   const [userEmail, setUserEmail] = useState<string | null>(shareSnapshot?.userEmail ?? null);
+  const [userDisplayName, setUserDisplayName] = useState(
+    formatNameFromEmail(shareSnapshot?.userEmail ?? null)
+  );
   const [isGetLinked, setIsGetLinked] = useState(shareSnapshot?.isGetLinked ?? false);
   const [getLinkedAt, setGetLinkedAt] = useState<string | null>(shareSnapshot?.getLinkedAt ?? null);
   const [getLoginUrlInput, setGetLoginUrlInput] = useState('');
@@ -103,12 +247,13 @@ export default function DonorScreen() {
 
   const loadUserAndImpact = useCallback(async (options?: { showBlockingLoader?: boolean }) => {
     const showBlockingLoader = options?.showBlockingLoader ?? false;
-    if (showBlockingLoader) {
-      setLoading(true);
-    }
+    if (showBlockingLoader) setLoading(true);
 
     try {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
       if (!user) {
         Alert.alert('Error', 'Please sign in first');
         return;
@@ -116,6 +261,7 @@ export default function DonorScreen() {
 
       const linkState = await getGetLinkStatus(user.id);
       let nextGetAccounts: GetAccountBalance[] = [];
+
       if (linkState.linked) {
         try {
           const accounts = await getGetAccounts(user.id);
@@ -143,6 +289,11 @@ export default function DonorScreen() {
 
       setUserId(nextSnapshot.userId);
       setUserEmail(nextSnapshot.userEmail);
+      setUserDisplayName(
+        typeof user.user_metadata?.full_name === 'string'
+          ? user.user_metadata.full_name
+          : formatNameFromEmail(user.email ?? null)
+      );
       setWeeklyAmount(nextSnapshot.weeklyAmount);
       setIsActive(nextSnapshot.isActive);
       setImpact(nextSnapshot.impact);
@@ -155,9 +306,7 @@ export default function DonorScreen() {
       console.error('Error loading impact:', error);
       Alert.alert('Error', 'Failed to load your donation data');
     } finally {
-      if (showBlockingLoader) {
-        setLoading(false);
-      }
+      if (showBlockingLoader) setLoading(false);
     }
   }, [markShareLoaded, setShareSnapshot]);
 
@@ -179,7 +328,17 @@ export default function DonorScreen() {
       getAccounts,
       ...overrides,
     });
-  }, [getAccounts, getLinkedAt, impact, isActive, isGetLinked, setShareSnapshot, userEmail, userId, weeklyAmount]);
+  }, [
+    getAccounts,
+    getLinkedAt,
+    impact,
+    isActive,
+    isGetLinked,
+    setShareSnapshot,
+    userEmail,
+    userId,
+    weeklyAmount,
+  ]);
 
   const ucscTrackedAccounts = getAccounts.filter((account) =>
     UCSC_TRACKED_BALANCE_ACCOUNTS.has(account.accountDisplayName.trim().toLowerCase())
@@ -189,13 +348,11 @@ export default function DonorScreen() {
     return sum + account.balance;
   }, 0);
 
-  // Load on first mount if we don't already have cached share data.
   useEffect(() => {
     if (hasShareSnapshot) return;
     void loadUserAndImpact({ showBlockingLoader: true });
   }, [hasShareSnapshot, loadUserAndImpact]);
 
-  // Refresh in the background when tab regains focus.
   useFocusEffect(
     useCallback(() => {
       if (!hasLoadedShare || !hasShareSnapshot) return;
@@ -207,7 +364,7 @@ export default function DonorScreen() {
     if (!userId) return;
 
     const amount = parseFloat(weeklyAmount);
-    if (isNaN(amount) || amount <= 0) {
+    if (Number.isNaN(amount) || amount <= 0) {
       Alert.alert('Invalid Amount', 'Please enter a valid amount');
       return;
     }
@@ -248,11 +405,13 @@ export default function DonorScreen() {
 
   const completeGetLink = async (validatedUrl: string) => {
     if (!userId) return;
+
     await linkGetAccount({
       userId,
       userEmail,
       validatedUrl: validatedUrl.trim(),
     });
+
     setGetLoginUrlInput('');
     Alert.alert('Success', 'Your GET account is now linked for sharing.');
     await loadUserAndImpact({ showBlockingLoader: false });
@@ -260,6 +419,7 @@ export default function DonorScreen() {
 
   const handleOpenGetLogin = async () => {
     if (!userId) return;
+
     try {
       const { loginUrl } = await getGetLoginUrl();
       await WebBrowser.openBrowserAsync(loginUrl);
@@ -334,6 +494,7 @@ export default function DonorScreen() {
 
   const handleRefreshBalance = async () => {
     if (!userId || !isGetLinked) return;
+
     setRefreshingBalance(true);
     try {
       const accounts = await getGetAccounts(userId);
@@ -349,6 +510,7 @@ export default function DonorScreen() {
 
   const handleSignOut = async () => {
     if (isSigningOut) return;
+
     setIsSigningOut(true);
     try {
       await signOut();
@@ -359,342 +521,560 @@ export default function DonorScreen() {
 
   if (loading) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ActivityIndicator size="large" color={uiColor('systemBlue')} />
+      <View style={styles.loadingScreen}>
+        <ActivityIndicator size="large" color={colors.brand} />
       </View>
     );
   }
 
-  return (
-    <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={{ padding: 16, gap: 16, paddingBottom: 32 }}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-      >
-        {/* Show Contribution/Impact first if GET is already linked */}
-        {isGetLinked && !isActive && (
-          <Card>
-            <Text style={{ fontSize: 17, fontWeight: '600', color: uiColor('label'), marginBottom: 4 }}>
-              Set Weekly Contribution
-            </Text>
-            <Text style={{ fontSize: 14, color: uiColor('secondaryLabel'), marginBottom: 20 }}>
-              Your contribution goes to a weekly pool that helps fellow students
-            </Text>
+  const donorName = userDisplayName;
+  const handleHeroAction = () => {
+    if (isGetLinked) {
+      router.push('/scan-card');
+      return;
+    }
 
-            <View style={{ gap: 8, marginBottom: 20 }}>
-              <Text style={{ fontSize: 14, fontWeight: '500', color: uiColor('label') }}>Weekly Amount (points)</Text>
-              <TextInput
-                style={{
-                  borderWidth: 0.5,
-                  borderColor: uiColor('separator'),
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  padding: 12,
-                  fontSize: 16,
-                  color: uiColor('label'),
-                  backgroundColor: uiColor('secondarySystemGroupedBackground'),
-                }}
-                value={weeklyAmount}
-                onChangeText={setWeeklyAmount}
-                keyboardType="numeric"
-                placeholder="e.g., 100"
-                placeholderTextColor={uiColor('placeholderText')}
+    void handleOpenGetLogin();
+  };
+
+  return (
+    <View style={styles.screen}>
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.brand}
+            colors={[colors.brand]}
+          />
+        }
+      >
+        <View style={styles.passCard}>
+          <View style={styles.passNotch} />
+          <Text style={styles.passTitle}>UCSC Dining Services</Text>
+          <View style={styles.passBand}>
+            <View style={styles.passAvatarShell}>
+              <SymbolView
+                name="person.crop.circle.badge.checkmark"
+                tintColor="rgba(255,255,255,0.88)"
+                size={112}
               />
             </View>
+          </View>
+          <View style={styles.passContent}>
+            <Text style={styles.passName}>{donorName}</Text>
 
             <Pressable
-              onPress={handleSetContribution}
-              disabled={saving}
-              style={({ pressed }) => ({
-                alignItems: 'center',
-                paddingVertical: 14,
-                borderRadius: 10,
-                borderCurve: 'continuous',
-                backgroundColor: uiColor('systemBlue'),
-                opacity: pressed ? 0.7 : saving ? 0.5 : 1,
-              })}
+              onPress={handleHeroAction}
+              style={({ pressed }) => [
+                styles.passActionPill,
+                { opacity: buttonOpacity(pressed, false) },
+              ]}
             >
-              {saving ? (
-                <ActivityIndicator color="#fff" />
-              ) : (
-                <Text style={{ color: '#fff', fontSize: 16, fontWeight: '600' }}>Start Sharing</Text>
-              )}
+              <SymbolView
+                name={isGetLinked ? 'barcode.viewfinder' : 'link'}
+                tintColor="#ffffff"
+                size={22}
+              />
+              <Text style={styles.passActionText}>{isGetLinked ? 'Scan Card' : 'Link GET'}</Text>
             </Pressable>
-          </Card>
-        )}
+          </View>
+        </View>
 
-        {isGetLinked && isActive && (
-          <Card>
-            <Text style={{ fontSize: 17, fontWeight: '600', color: uiColor('label'), marginBottom: 16 }}>
-              Your Impact
-            </Text>
-            <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginBottom: 20 }}>
-              <View style={{ alignItems: 'center' }}>
-                <Text selectable style={{ fontSize: 32, fontWeight: 'bold', color: uiColor('systemBlue'), fontVariant: ['tabular-nums'] }}>
-                  {impact.peopleHelped}
-                </Text>
-                <Text style={{ fontSize: 13, color: uiColor('secondaryLabel'), marginTop: 4 }}>People Helped</Text>
-              </View>
-              <View style={{ alignItems: 'center' }}>
-                <Text selectable style={{ fontSize: 32, fontWeight: 'bold', color: uiColor('systemBlue'), fontVariant: ['tabular-nums'] }}>
-                  {weeklyAmount}
-                </Text>
-                <Text style={{ fontSize: 13, color: uiColor('secondaryLabel'), marginTop: 4 }}>Points/Week</Text>
-              </View>
-            </View>
-
-            <Pressable
-              onPress={handlePause}
-              disabled={saving}
-              style={({ pressed }) => ({
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 6,
-                paddingVertical: 14,
-                borderRadius: 10,
-                borderCurve: 'continuous',
-                backgroundColor: uiColor('tertiarySystemFill'),
-                opacity: pressed ? 0.7 : saving ? 0.5 : 1,
-              })}
-            >
-              {saving ? (
-                <ActivityIndicator size="small" color={uiColor('systemBlue')} />
-              ) : (
-                <>
-                  <SymbolView
-                    name={isActive ? 'pause.fill' : 'play.fill'}
-                    tintColor={uiColor('systemBlue')}
-                    size={14}
-                  />
-                  <Text style={{ color: uiColor('systemBlue'), fontSize: 16, fontWeight: '600' }}>
-                    {isActive ? 'Pause' : 'Resume'} Sharing
-                  </Text>
-                </>
-              )}
-            </Pressable>
-          </Card>
-        )}
-
-        {isGetLinked && isActive && (
-          <Card>
-            <Text style={{ fontSize: 17, fontWeight: '600', color: uiColor('label'), marginBottom: 16 }}>
-              Weekly Cap
-            </Text>
-            <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 }}>
-              <Text style={{ fontSize: 13, color: uiColor('secondaryLabel') }}>Cap</Text>
-              <Text selectable style={{ fontSize: 13, color: uiColor('label'), fontVariant: ['tabular-nums'] }}>
-                {impact.capAmount.toFixed(2)} pts
-              </Text>
-            </View>
-            <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 }}>
-              <Text style={{ fontSize: 13, color: uiColor('secondaryLabel') }}>Redeemed</Text>
-              <Text selectable style={{ fontSize: 13, color: uiColor('label'), fontVariant: ['tabular-nums'] }}>
-                {impact.redeemedThisWeek.toFixed(2)} pts
-              </Text>
-            </View>
-            <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 }}>
-              <Text style={{ fontSize: 13, color: uiColor('secondaryLabel') }}>Reserved</Text>
-              <Text selectable style={{ fontSize: 13, color: uiColor('label'), fontVariant: ['tabular-nums'] }}>
-                {impact.reservedThisWeek.toFixed(2)} pts
-              </Text>
-            </View>
-            <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 }}>
-              <Text style={{ fontSize: 13, color: uiColor('secondaryLabel') }}>Remaining</Text>
-              <Text selectable style={{ fontSize: 13, color: impact.capReached ? uiColor('systemRed') : uiColor('systemGreen'), fontVariant: ['tabular-nums'] }}>
-                {impact.remainingThisWeek.toFixed(2)} pts
-              </Text>
-            </View>
-            <Text style={{ fontSize: 12, color: uiColor('tertiaryLabel'), marginTop: 8 }}>
-              Tracking week in {impact.timezone}
-            </Text>
-          </Card>
-        )}
-
-        {/* GET Account Balance Card */}
-        <Card>
-          <Text style={{ fontSize: 17, fontWeight: '600', color: uiColor('label'), marginBottom: 12 }}>
-            Available GET Balance
-          </Text>
+        <SectionCard>
+          <SectionHeader
+            icon="dollarsign.circle"
+            title="Accounts"
+            detail={isGetLinked ? 'Your live GET balances' : 'Connect GET to sync campus balances'}
+          />
 
           {isGetLinked ? (
-            <View style={{ gap: 12 }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <SymbolView name="checkmark.circle.fill" tintColor={uiColor('systemGreen')} size={16} />
-                <Text style={{ fontSize: 14, color: uiColor('systemGreen') }}>
-                  Linked{getLinkedAt ? ` on ${new Date(getLinkedAt).toLocaleDateString()}` : ''}
+            <>
+              <View style={styles.balanceHero}>
+                <Text style={styles.balanceHeroLabel}>Total available</Text>
+                <Text style={styles.balanceHeroValue}>{totalAvailableBalance.toFixed(2)} pts</Text>
+                <Text style={styles.balanceHeroMeta}>
+                  {getLinkedAt ? `Linked ${new Date(getLinkedAt).toLocaleDateString()}` : 'Linked'}
                 </Text>
               </View>
 
-              <View style={{
-                backgroundColor: uiColor('tertiarySystemFill'),
-                borderRadius: 12,
-                padding: 14,
-                borderCurve: 'continuous',
-              }}>
-                <Text style={{ fontSize: 12, color: uiColor('secondaryLabel'), marginBottom: 4 }}>
-                  Total Available (Flexi + Banana + Slug)
-                </Text>
-                <Text style={{ fontSize: 28, color: uiColor('systemBlue'), fontWeight: '700', fontVariant: ['tabular-nums'] }}>
-                  {totalAvailableBalance.toFixed(2)} pts
-                </Text>
-              </View>
-
-              <Text style={{ fontSize: 13, color: uiColor('secondaryLabel') }}>Tracked accounts</Text>
               {ucscTrackedAccounts.length > 0 ? (
-                <View style={{ gap: 0 }}>
+                <View style={styles.metricGrid}>
                   {ucscTrackedAccounts.map((account) => (
-                    <View key={account.id} style={{
-                      flexDirection: 'row',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      paddingVertical: 8,
-                      borderBottomWidth: 0.5,
-                      borderBottomColor: uiColor('separator'),
-                    }}>
-                      <Text style={{ fontSize: 15, color: uiColor('label'), flex: 1, marginRight: 8 }}>
-                        {account.accountDisplayName}
-                      </Text>
-                      <Text selectable style={{ fontSize: 15, color: uiColor('systemBlue'), fontWeight: '600', fontVariant: ['tabular-nums'] }}>
-                        {account.balance ?? 'n/a'} pts
-                      </Text>
-                    </View>
+                    <MetricTile
+                      key={account.id}
+                      label={account.accountDisplayName}
+                      value={`${typeof account.balance === 'number' ? account.balance.toFixed(2) : 'n/a'} pts`}
+                    />
                   ))}
                 </View>
               ) : (
-                <Text style={{ fontSize: 13, color: uiColor('tertiaryLabel') }}>
-                  Linked, but no tracked UCSC balance accounts were returned.
-                </Text>
+                <View style={styles.emptyState}>
+                  <Text style={styles.emptyCopy}>
+                    Linked successfully, but GET did not return the tracked UCSC account balances yet.
+                  </Text>
+                </View>
               )}
 
-              <Pressable
-                onPress={handleRefreshBalance}
-                disabled={refreshingBalance}
-                style={({ pressed }) => ({
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 6,
-                  paddingVertical: 12,
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  backgroundColor: uiColor('tertiarySystemFill'),
-                  opacity: pressed ? 0.7 : refreshingBalance ? 0.5 : 1,
-                })}
-              >
-                {refreshingBalance ? (
-                  <ActivityIndicator size="small" color={uiColor('systemBlue')} />
-                ) : (
-                  <>
-                    <SymbolView name="arrow.clockwise" tintColor={uiColor('systemBlue')} size={14} />
-                    <Text style={{ color: uiColor('systemBlue'), fontWeight: '600', fontSize: 15 }}>Refresh Balance</Text>
-                  </>
-                )}
-              </Pressable>
-
-              <Pressable
-                onPress={handleUnlinkGet}
-                disabled={unlinkingGet}
-                style={({ pressed }) => ({
-                  alignItems: 'center',
-                  paddingVertical: 12,
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  backgroundColor: uiColor('tertiarySystemFill'),
-                  opacity: pressed ? 0.7 : unlinkingGet ? 0.5 : 1,
-                })}
-              >
-                <Text style={{ color: uiColor('systemRed'), fontWeight: '600', fontSize: 15 }}>
-                  {unlinkingGet ? 'Unlinking...' : 'Unlink GET'}
-                </Text>
-              </Pressable>
-            </View>
+              <View style={styles.buttonRow}>
+                <SecondaryButton
+                  label="Refresh Balance"
+                  onPress={() => {
+                    void handleRefreshBalance();
+                  }}
+                  icon="arrow.clockwise"
+                  loading={refreshingBalance}
+                />
+                <SecondaryButton
+                  label="Unlink GET"
+                  onPress={handleUnlinkGet}
+                  destructive
+                  loading={unlinkingGet}
+                />
+              </View>
+            </>
           ) : (
-            <View style={{ gap: 12 }}>
-              <Text style={{ fontSize: 14, color: uiColor('secondaryLabel'), lineHeight: 20 }}>
-                Continue to GET and sign in. Once it says 'validated', tap the share icon then copy, and paste the URL below to finish linking.
+            <View style={styles.connectBlock}>
+              <Text style={styles.connectCopy}>
+                Continue to GET, sign in, then paste the validated URL back here to finish linking your donor pass.
               </Text>
 
-              <Pressable
-                onPress={handleOpenGetLogin}
-                disabled={linkingGet}
-                style={({ pressed }) => ({
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 6,
-                  paddingVertical: 12,
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  backgroundColor: uiColor('tertiarySystemFill'),
-                  opacity: pressed ? 0.7 : linkingGet ? 0.5 : 1,
-                })}
-              >
-                {linkingGet ? (
-                  <ActivityIndicator size="small" color={uiColor('systemBlue')} />
-                ) : (
-                  <>
-                    <SymbolView name="arrow.up.right" tintColor={uiColor('systemBlue')} size={14} />
-                    <Text style={{ color: uiColor('systemBlue'), fontWeight: '600', fontSize: 15 }}>Open GET Login</Text>
-                  </>
-                )}
-              </Pressable>
+              <View style={styles.buttonRow}>
+                <SecondaryButton
+                  label="Open GET Login"
+                  onPress={() => {
+                    void handleOpenGetLogin();
+                  }}
+                  icon="arrow.up.right"
+                />
+              </View>
 
               <TextInput
-                style={{
-                  borderWidth: 0.5,
-                  borderColor: uiColor('separator'),
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  padding: 12,
-                  fontSize: 15,
-                  color: uiColor('label'),
-                  backgroundColor: uiColor('secondarySystemGroupedBackground'),
-                }}
+                style={styles.input}
                 value={getLoginUrlInput}
                 onChangeText={setGetLoginUrlInput}
                 placeholder="Paste validated GET URL here"
-                placeholderTextColor={uiColor('placeholderText')}
+                placeholderTextColor={colors.textSoft}
                 autoCapitalize="none"
                 autoCorrect={false}
               />
 
-              <Pressable
-                onPress={handleLinkGet}
-                disabled={linkingGet}
-                style={({ pressed }) => ({
-                  alignItems: 'center',
-                  paddingVertical: 14,
-                  borderRadius: 10,
-                  borderCurve: 'continuous',
-                  backgroundColor: uiColor('systemBlue'),
-                  opacity: pressed ? 0.7 : linkingGet ? 0.5 : 1,
-                })}
-              >
-                {linkingGet ? (
-                  <ActivityIndicator color="#fff" />
-                ) : (
-                  <Text style={{ color: '#fff', fontSize: 16, fontWeight: '600' }}>Link from Pasted URL</Text>
-                )}
-              </Pressable>
+              <PrimaryButton
+                label="Link from Pasted URL"
+                onPress={() => {
+                  void handleLinkGet();
+                }}
+                loading={linkingGet}
+              />
             </View>
           )}
-        </Card>
+        </SectionCard>
 
-        {/* Log Out */}
+        {isGetLinked ? (
+          <SectionCard>
+            <SectionHeader
+              icon="heart.text.square"
+              title={isActive ? 'Sharing Settings' : 'Start Sharing'}
+              detail={
+                isActive
+                  ? 'Control your weekly contribution and donor status'
+                  : 'Set the weekly amount you want to contribute'
+              }
+            />
+
+            {!isActive ? (
+              <>
+                <Text style={styles.formLabel}>Weekly amount (points)</Text>
+                <TextInput
+                  style={styles.input}
+                  value={weeklyAmount}
+                  onChangeText={setWeeklyAmount}
+                  keyboardType="numeric"
+                  placeholder="e.g. 100"
+                  placeholderTextColor={colors.textSoft}
+                />
+                <PrimaryButton
+                  label="Start Sharing"
+                  onPress={() => {
+                    void handleSetContribution();
+                  }}
+                  loading={saving}
+                />
+              </>
+            ) : (
+              <>
+                <View style={styles.metricGrid}>
+                  <MetricTile label="People helped" value={String(impact.peopleHelped)} emphasized />
+                  <MetricTile label="Points / week" value={`${weeklyAmount || '0'} pts`} />
+                  <MetricTile label="Redeemed" value={`${impact.redeemedThisWeek.toFixed(2)} pts`} />
+                  <MetricTile label="Reserved" value={`${impact.reservedThisWeek.toFixed(2)} pts`} />
+                </View>
+
+                <View style={styles.capCard}>
+                  <View style={styles.capRow}>
+                    <Text style={styles.capLabel}>Weekly cap</Text>
+                    <Text style={styles.capValue}>{impact.capAmount.toFixed(2)} pts</Text>
+                  </View>
+                  <View style={styles.capRow}>
+                    <Text style={styles.capLabel}>Remaining</Text>
+                    <Text style={[styles.capValue, impact.capReached ? styles.negativeValue : styles.positiveValue]}>
+                      {impact.remainingThisWeek.toFixed(2)} pts
+                    </Text>
+                  </View>
+                  <Text style={styles.capFootnote}>Tracking week in {impact.timezone}</Text>
+                </View>
+
+                <View style={styles.buttonRow}>
+                  <SecondaryButton
+                    label={isActive ? 'Pause Sharing' : 'Resume Sharing'}
+                    onPress={() => {
+                      void handlePause();
+                    }}
+                    icon={isActive ? 'pause.fill' : 'play.fill'}
+                    loading={saving}
+                  />
+                </View>
+              </>
+            )}
+          </SectionCard>
+        ) : null}
+
         <Pressable
-          onPress={handleSignOut}
+          onPress={() => {
+            void handleSignOut();
+          }}
           disabled={isSigningOut}
-          style={({ pressed }) => ({
-            alignItems: 'center',
-            paddingVertical: 10,
-            opacity: pressed ? 0.5 : isSigningOut ? 0.5 : 1,
-          })}
+          style={({ pressed }) => [{ opacity: buttonOpacity(pressed, isSigningOut) }]}
         >
-          <Text style={{ color: uiColor('systemRed'), fontSize: 15 }}>
-            {isSigningOut ? 'Signing out...' : 'Log out'}
-          </Text>
+          <Text style={styles.logoutText}>{isSigningOut ? 'Signing out...' : 'Log out'}</Text>
         </Pressable>
       </ScrollView>
+
+      <GetMobileTabBar active="home" />
+    </View>
   );
 }
+
+const colors = stealthTheme.colors;
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.canvas,
+  },
+  content: {
+    padding: 18,
+    gap: 18,
+    paddingBottom: 116,
+  },
+  loadingScreen: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.canvas,
+  },
+  passCard: {
+    borderRadius: 26,
+    overflow: 'hidden',
+    backgroundColor: colors.brand,
+    borderWidth: 1,
+    borderColor: colors.brandDark,
+    ...cardShadow('hero'),
+  },
+  passNotch: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: 92,
+    height: 92,
+    backgroundColor: colors.brandDark,
+  },
+  passTitle: {
+    paddingTop: 26,
+    paddingHorizontal: 20,
+    paddingBottom: 18,
+    textAlign: 'center',
+    color: '#ffffff',
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: '500',
+  },
+  passBand: {
+    height: 136,
+    backgroundColor: colors.brandDark,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: colors.brandDeeper,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  passAvatarShell: {
+    width: 156,
+    height: 156,
+    borderRadius: 78,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.94)',
+    marginTop: 48,
+  },
+  passContent: {
+    paddingHorizontal: 20,
+    paddingTop: 94,
+    paddingBottom: 20,
+    gap: 12,
+  },
+  passName: {
+    color: '#ffffff',
+    fontSize: 22,
+    lineHeight: 28,
+    fontWeight: '500',
+  },
+  passActionPill: {
+    marginTop: 2,
+    minHeight: 62,
+    borderRadius: 18,
+    backgroundColor: colors.brandDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    paddingHorizontal: 16,
+  },
+  passActionText: {
+    color: '#ffffff',
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  sectionCard: {
+    borderRadius: 24,
+    paddingTop: 14,
+    paddingBottom: 18,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    ...cardShadow(),
+  },
+  sectionHeader: {
+    paddingHorizontal: 18,
+    paddingBottom: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.surfaceStrong,
+  },
+  sectionHeaderLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  sectionIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  sectionHeaderText: {
+    flex: 1,
+    gap: 2,
+  },
+  sectionTitle: {
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  sectionDetail: {
+    ...typeScale.caption,
+    color: colors.textMuted,
+  },
+  balanceHero: {
+    marginHorizontal: 18,
+    marginTop: 16,
+    padding: 16,
+    borderRadius: 18,
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  balanceHeroLabel: {
+    ...typeScale.caption,
+    color: colors.textMuted,
+  },
+  balanceHeroValue: {
+    marginTop: 4,
+    color: colors.brand,
+    fontSize: 30,
+    lineHeight: 34,
+    fontWeight: '700',
+  },
+  balanceHeroMeta: {
+    marginTop: 4,
+    ...typeScale.caption,
+    color: colors.textSoft,
+  },
+  metricGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    paddingHorizontal: 18,
+    paddingTop: 16,
+  },
+  metricTile: {
+    minWidth: '47%',
+    flexGrow: 1,
+    borderRadius: 16,
+    padding: 14,
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+    gap: 8,
+  },
+  metricTileAccent: {
+    backgroundColor: colors.accentMuted,
+    borderColor: '#c5d6ff',
+  },
+  metricLabel: {
+    ...typeScale.caption,
+    color: colors.textMuted,
+    textTransform: 'none',
+    letterSpacing: 0,
+  },
+  metricValue: {
+    color: colors.text,
+    fontSize: 24,
+    lineHeight: 28,
+    fontWeight: '700',
+  },
+  metricValueAccent: {
+    color: colors.brand,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    paddingHorizontal: 18,
+    paddingTop: 16,
+  },
+  secondaryButton: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    borderRadius: 16,
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+    flexGrow: 1,
+  },
+  secondaryButtonLabel: {
+    color: colors.brand,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  destructiveLabel: {
+    color: colors.danger,
+  },
+  primaryButton: {
+    minHeight: 52,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 16,
+    backgroundColor: colors.brand,
+    marginHorizontal: 18,
+    marginTop: 16,
+  },
+  primaryButtonLabel: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  connectBlock: {
+    paddingTop: 16,
+    gap: 12,
+  },
+  connectCopy: {
+    paddingHorizontal: 18,
+    ...typeScale.body,
+    color: colors.textMuted,
+  },
+  input: {
+    marginHorizontal: 18,
+    minHeight: 50,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 16,
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    color: colors.text,
+    fontSize: 15,
+  },
+  formLabel: {
+    paddingHorizontal: 18,
+    paddingTop: 16,
+    ...typeScale.caption,
+    color: colors.textMuted,
+  },
+  emptyState: {
+    marginHorizontal: 18,
+    marginTop: 16,
+    borderRadius: 18,
+    padding: 16,
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  emptyCopy: {
+    ...typeScale.body,
+    color: colors.textMuted,
+  },
+  capCard: {
+    marginHorizontal: 18,
+    marginTop: 16,
+    borderRadius: 18,
+    padding: 16,
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+    gap: 10,
+  },
+  capRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  capLabel: {
+    ...typeScale.caption,
+    color: colors.textMuted,
+  },
+  capValue: {
+    color: colors.text,
+    fontSize: 15,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  positiveValue: {
+    color: colors.success,
+  },
+  negativeValue: {
+    color: colors.danger,
+  },
+  capFootnote: {
+    ...typeScale.caption,
+    color: colors.textSoft,
+  },
+  logoutText: {
+    textAlign: 'center',
+    color: colors.danger,
+    fontSize: 15,
+    fontWeight: '600',
+    paddingVertical: 6,
+  },
+});

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,23 +1,62 @@
-import {
-  NativeTabs,
-  Icon,
-  Label,
-} from "expo-router/unstable-native-tabs";
-import { TabCacheProvider } from "../../../../lib/tab-cache-context";
+import { Tabs } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { TabCacheProvider } from '../../../../lib/tab-cache-context';
+import { stealthTheme } from '../../lib/stealth-theme';
+
+function TabIcon({
+  focused,
+  color,
+  name,
+  activeName,
+}: {
+  focused: boolean;
+  color: string;
+  name: keyof typeof Ionicons.glyphMap;
+  activeName: keyof typeof Ionicons.glyphMap;
+}) {
+  return (
+    <Ionicons
+      name={focused ? activeName : name}
+      size={24}
+      color={color}
+      style={{ marginTop: 6 }}
+    />
+  );
+}
 
 export default function TabLayout() {
+  const colors = stealthTheme.colors;
+
   return (
     <TabCacheProvider>
-      <NativeTabs minimizeBehavior="onScrollDown">
-        <NativeTabs.Trigger name="(share)">
-          <Icon sf={{ default: "heart", selected: "heart.fill" }} />
-          <Label>Share</Label>
-        </NativeTabs.Trigger>
-        <NativeTabs.Trigger name="(request)">
-          <Icon sf={{ default: "hand.raised", selected: "hand.raised.fill" }} />
-          <Label>Request</Label>
-        </NativeTabs.Trigger>
-      </NativeTabs>
+      <Tabs
+        screenOptions={{
+          headerShown: false,
+          tabBarStyle: {
+            display: 'none',
+            backgroundColor: colors.surface,
+          },
+        }}
+      >
+        <Tabs.Screen
+          name="(share)"
+          options={{
+            title: 'Share',
+            tabBarIcon: ({ focused, color }) => (
+              <TabIcon focused={focused} color={color} name="heart-outline" activeName="heart" />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="(request)"
+          options={{
+            title: 'Request',
+            tabBarIcon: ({ focused, color }) => (
+              <TabIcon focused={focused} color={color} name="qr-code-outline" activeName="qr-code" />
+            ),
+          }}
+        />
+      </Tabs>
     </TabCacheProvider>
   );
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import Constants from 'expo-constants';
 import { getMobileAppConfig } from '../../../lib/api';
-import { uiColor } from '../lib/ui-color';
+import { cardShadow, stealthTheme } from '../lib/stealth-theme';
 
 type RequiredUpdateGate = {
   installedVersion: string;
@@ -218,19 +218,24 @@ export default function RootLayout() {
     }
   }, [requiredUpdateGate]);
 
-  const modalBgColor = Platform.OS === 'ios' ? uiColor('systemBackground') : '#1f1f1f';
-  const labelColor = Platform.OS === 'ios' ? uiColor('label') : '#ffffff';
-  const secondaryColor = Platform.OS === 'ios' ? uiColor('secondaryLabel') : '#b7b7b7';
+  const colors = stealthTheme.colors;
 
   try {
     return (
       <AuthProvider>
-        <StatusBar style="auto" />
+        <StatusBar style="dark" />
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="index" />
           <Stack.Screen name="auth/sign-in" />
           <Stack.Screen name="auth/callback" />
           <Stack.Screen name="(tabs)" />
+          <Stack.Screen
+            name="scan-card"
+            options={{
+              headerShown: false,
+              presentation: 'fullScreenModal',
+            }}
+          />
         </Stack>
 
         <Modal
@@ -244,27 +249,30 @@ export default function RootLayout() {
               flex: 1,
               justifyContent: 'center',
               padding: 24,
-              backgroundColor: 'rgba(0, 0, 0, 0.6)',
+              backgroundColor: colors.overlay,
             }}
           >
             <View
               style={{
-                backgroundColor: modalBgColor,
-                borderRadius: 16,
-                padding: 20,
+                backgroundColor: colors.surface,
+                borderRadius: stealthTheme.radii.md,
+                padding: 22,
                 gap: 12,
+                borderWidth: 1,
+                borderColor: colors.border,
+                ...cardShadow('hero'),
               }}
             >
-              <Text selectable style={{ fontSize: 22, fontWeight: '700', color: labelColor }}>
+              <Text selectable style={{ fontSize: 22, fontWeight: '700', color: colors.text }}>
                 Update required
               </Text>
-              <Text selectable style={{ fontSize: 14, color: secondaryColor }}>
+              <Text selectable style={{ fontSize: 14, color: colors.textMuted }}>
                 Your app version is no longer supported.
               </Text>
-              <Text selectable style={{ fontSize: 14, color: secondaryColor }}>
+              <Text selectable style={{ fontSize: 14, color: colors.textMuted }}>
                 Installed: {requiredUpdateGate?.installedVersion ?? 'unknown'}
               </Text>
-              <Text selectable style={{ fontSize: 14, color: secondaryColor }}>
+              <Text selectable style={{ fontSize: 14, color: colors.textMuted }}>
                 Required: {requiredUpdateGate?.requiredVersion ?? 'unknown'}+
               </Text>
 
@@ -274,9 +282,9 @@ export default function RootLayout() {
                 }}
                 style={{
                   marginTop: 8,
-                  borderRadius: 12,
-                  backgroundColor: '#0a84ff',
-                  paddingVertical: 12,
+                  borderRadius: stealthTheme.radii.sm,
+                  backgroundColor: colors.brand,
+                  paddingVertical: 13,
                   alignItems: 'center',
                 }}
               >
@@ -292,9 +300,19 @@ export default function RootLayout() {
   } catch (error) {
     console.error('Error in RootLayout:', error);
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 }}>
-        <Text style={{ color: 'red', marginBottom: 10 }}>Error loading app:</Text>
-        <Text>{String(error)}</Text>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          padding: 20,
+          backgroundColor: colors.canvas,
+        }}
+      >
+        <Text style={{ color: colors.danger, marginBottom: 10, fontWeight: '700' }}>
+          Error loading app:
+        </Text>
+        <Text style={{ color: colors.text }}>{String(error)}</Text>
       </View>
     );
   }

--- a/apps/mobile/app/auth/sign-in.tsx
+++ b/apps/mobile/app/auth/sign-in.tsx
@@ -1,16 +1,16 @@
-import { View, Text, Pressable, Alert, ActivityIndicator, Platform } from 'react-native';
-import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
+import { View, Text, Pressable, Alert, ActivityIndicator, Platform, StyleSheet } from 'react-native';
 import { SymbolView } from 'expo-symbols';
 import { supabase } from '../../../../lib/supabase';
 import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
 import { useState } from 'react';
-import { uiColor } from '../../lib/ui-color';
+import { buttonOpacity, cardShadow, stealthTheme, typeScale } from '../../lib/stealth-theme';
 
 WebBrowser.maybeCompleteAuthSession();
 
 export default function SignIn() {
   const [loading, setLoading] = useState(false);
+  const colors = stealthTheme.colors;
 
   const handleGoogleSignIn = async () => {
     setLoading(true);
@@ -84,94 +84,171 @@ export default function SignIn() {
   };
 
   return (
-    <View style={{
-      flex: 1,
-      justifyContent: 'center',
-      alignItems: 'center',
-      padding: 24,
-      backgroundColor: uiColor('systemGroupedBackground'),
-    }}>
-      <View style={{ alignItems: 'center', marginBottom: 48 }}>
-        <SymbolView
-          name="fork.knife.circle.fill"
-          tintColor={uiColor('systemBlue')}
-          size={64}
-          weight="light"
-        />
-        <Text style={{
-          fontSize: 42,
-          fontWeight: 'bold',
-          color: uiColor('label'),
-          marginTop: 16,
-        }}>
-          SlugSwap
-        </Text>
-        <Text style={{
-          fontSize: 17,
-          color: uiColor('secondaryLabel'),
-          marginTop: 8,
-        }}>
-          Share dining points with fellow students
-        </Text>
+    <View style={styles.screen}>
+      <View style={styles.heroCard}>
+        <View style={styles.heroNotch} />
+        <Text style={styles.heroTitle}>UCSC Dining Services</Text>
+        <View style={styles.heroBand} />
+        <View style={styles.heroBody}>
+          <View style={styles.avatarShell}>
+            <SymbolView name="person.crop.circle" tintColor="rgba(255, 255, 255, 0.92)" size={90} />
+          </View>
+          <Text style={styles.appName}>SlugSwap</Text>
+          <Text style={styles.appSubtitle}>
+            A quieter, familiar pass-style experience for sharing dining points.
+          </Text>
+        </View>
       </View>
 
-      {isLiquidGlassAvailable() ? (
-        <GlassView isInteractive style={{ borderRadius: 14, width: '100%' }}>
-          <Pressable
-            onPress={handleGoogleSignIn}
-            disabled={loading}
-            style={({ pressed }) => ({
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 8,
-              paddingVertical: 16,
-              paddingHorizontal: 32,
-              opacity: pressed ? 0.7 : loading ? 0.6 : 1,
-            })}
-          >
-            {loading ? (
-              <ActivityIndicator color={uiColor('label')} />
-            ) : (
-              <>
-                <SymbolView name="person.crop.circle" tintColor={uiColor('label')} size={20} />
-                <Text style={{ color: uiColor('label'), fontSize: 17, fontWeight: '600' }}>
-                  Sign in with Google
-                </Text>
-              </>
-            )}
-          </Pressable>
-        </GlassView>
-      ) : (
+      <View style={styles.panel}>
+        <Text style={styles.panelTitle}>Sign in to continue</Text>
+        <Text style={styles.panelCopy}>
+          Use your Google account to open your donor or requester pass and keep your data synced.
+        </Text>
+
         <Pressable
           onPress={handleGoogleSignIn}
           disabled={loading}
-          style={({ pressed }) => ({
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 8,
-            paddingVertical: 16,
-            paddingHorizontal: 32,
-            borderRadius: 14,
-            borderCurve: 'continuous',
-            backgroundColor: uiColor('systemBlue'),
-            opacity: pressed ? 0.7 : loading ? 0.6 : 1,
-            width: '100%',
-          })}
+          style={({ pressed }) => [styles.signInButton, { opacity: buttonOpacity(pressed, loading) }]}
         >
           {loading ? (
             <ActivityIndicator color="#fff" />
           ) : (
             <>
               <SymbolView name="person.crop.circle" tintColor="#fff" size={20} />
-              <Text style={{ color: '#fff', fontSize: 17, fontWeight: '600' }}>
-                Sign in with Google
-              </Text>
+              <Text style={styles.signInLabel}>Sign in with Google</Text>
             </>
           )}
         </Pressable>
-      )}
+
+        <View style={styles.inlineMeta}>
+          <View style={[styles.metaDot, { backgroundColor: colors.brand }]} />
+          <Text style={styles.metaText}>Styled to echo the official GET Mobile pass</Text>
+        </View>
+      </View>
     </View>
   );
 }
+
+const colors = stealthTheme.colors;
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+    gap: 18,
+    backgroundColor: colors.canvas,
+  },
+  heroCard: {
+    borderRadius: stealthTheme.radii.lg,
+    overflow: 'hidden',
+    backgroundColor: colors.brand,
+    borderWidth: 1,
+    borderColor: colors.brandDark,
+    ...cardShadow('hero'),
+  },
+  heroNotch: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: 92,
+    height: 90,
+    backgroundColor: colors.brandDark,
+  },
+  heroTitle: {
+    paddingTop: 24,
+    paddingHorizontal: 20,
+    paddingBottom: 18,
+    color: '#ffffff',
+    textAlign: 'center',
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: '500',
+  },
+  heroBand: {
+    height: 112,
+    backgroundColor: colors.brandDark,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: colors.brandDeeper,
+  },
+  heroBody: {
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingTop: 18,
+    paddingBottom: 24,
+    backgroundColor: colors.brand,
+  },
+  avatarShell: {
+    width: 124,
+    height: 124,
+    borderRadius: 62,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.16)',
+    borderWidth: 6,
+    borderColor: 'rgba(255, 255, 255, 0.9)',
+    marginTop: -72,
+    marginBottom: 14,
+  },
+  appName: {
+    ...typeScale.headline,
+    color: '#ffffff',
+    fontSize: 28,
+    lineHeight: 32,
+  },
+  appSubtitle: {
+    marginTop: 8,
+    textAlign: 'center',
+    color: 'rgba(255, 255, 255, 0.84)',
+    fontSize: 15,
+    lineHeight: 21,
+  },
+  panel: {
+    borderRadius: stealthTheme.radii.lg,
+    padding: 22,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    gap: 16,
+    ...cardShadow(),
+  },
+  panelTitle: {
+    ...typeScale.title,
+    color: colors.text,
+  },
+  panelCopy: {
+    ...typeScale.body,
+    color: colors.textMuted,
+  },
+  signInButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    borderRadius: stealthTheme.radii.md,
+    backgroundColor: colors.brand,
+  },
+  signInLabel: {
+    color: '#fff',
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  inlineMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  metaDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 999,
+  },
+  metaText: {
+    ...typeScale.caption,
+    color: colors.textSoft,
+  },
+});

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,14 +1,22 @@
 import { View, ActivityIndicator, Text } from 'react-native';
 import { useAuth } from '../../../lib/auth-context';
-import { uiColor } from '../lib/ui-color';
+import { stealthTheme } from '../lib/stealth-theme';
 
 export default function Index() {
   const { isLoading } = useAuth();
+  const colors = stealthTheme.colors;
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: uiColor('systemGroupedBackground') }}>
-      <ActivityIndicator size="large" color={uiColor('systemBlue')} />
-      <Text style={{ marginTop: 16, color: uiColor('secondaryLabel') }}>
+    <View
+      style={{
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: colors.canvas,
+      }}
+    >
+      <ActivityIndicator size="large" color={colors.brand} />
+      <Text style={{ marginTop: 16, color: colors.textMuted, fontWeight: '600' }}>
         {isLoading ? 'Loading...' : 'Redirecting...'}
       </Text>
     </View>

--- a/apps/mobile/app/scan-card.tsx
+++ b/apps/mobile/app/scan-card.tsx
@@ -1,0 +1,446 @@
+import { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SymbolView } from 'expo-symbols';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { PDF417Barcode } from '../components/PDF417Barcode';
+import { supabase } from '../../../lib/supabase';
+import {
+  checkRedemption,
+  generateClaimCode,
+  getRequesterAllowance,
+  refreshClaimCode,
+  type CheckoutRail,
+  type ClaimGenerationFailureReason,
+} from '../../../lib/api';
+import { cardShadow, monoFontFamily, stealthTheme, typeScale } from '../lib/stealth-theme';
+
+interface ClaimCode {
+  id: string;
+  code: string;
+  amount: number;
+  expiresAt: string;
+  status?: string;
+  redemptionAmount?: number;
+  redemptionAccount?: string;
+  recommendedRail?: CheckoutRail;
+  donorDisplayName?: string | null;
+}
+
+const DEFAULT_CLAIM_AMOUNT = 10;
+const FLEXI_ACCOUNT_NAME = 'flexi dollars';
+const POINTS_OR_BUCKS_ACCOUNT_NAMES = new Set(['banana bucks', 'slug points']);
+const LEGACY_POOL_EXHAUSTED_MESSAGES = [
+  'No eligible donors available under weekly cap limits.',
+  'No eligible donors available.',
+];
+
+function getClaimFailureReason(error: unknown): ClaimGenerationFailureReason | null {
+  if (!error || typeof error !== 'object') return null;
+
+  if ('reason' in error) {
+    const reason = (error as { reason?: unknown }).reason;
+    if (typeof reason === 'string') {
+      return reason as ClaimGenerationFailureReason;
+    }
+  }
+
+  const message = 'message' in error ? (error as { message?: unknown }).message : undefined;
+  if (
+    typeof message === 'string' &&
+    LEGACY_POOL_EXHAUSTED_MESSAGES.some((legacyMessage) => message.includes(legacyMessage))
+  ) {
+    return 'pool_exhausted';
+  }
+
+  return null;
+}
+
+function inferCheckoutRail(accountName?: string): CheckoutRail | null {
+  if (!accountName) return null;
+  const normalized = accountName.trim().toLowerCase();
+  if (normalized === FLEXI_ACCOUNT_NAME) return 'flexi-dollars';
+  if (POINTS_OR_BUCKS_ACCOUNT_NAMES.has(normalized)) return 'points-or-bucks';
+  return null;
+}
+
+function formatDisplayName(email: string | null, fullName?: string | null) {
+  if (fullName?.trim()) return fullName;
+  if (!email) return 'SlugSwap User';
+
+  return email
+    .split('@')[0]
+    .split(/[._-]/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+export default function ScanCardScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const [displayName, setDisplayName] = useState('Loading...');
+  const [userId, setUserId] = useState<string | null>(null);
+  const [currentCode, setCurrentCode] = useState<ClaimCode | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState<string | null>(null);
+  const [timeRemaining, setTimeRemaining] = useState('');
+  const [refreshingCode, setRefreshingCode] = useState(false);
+  const [redemptionMessage, setRedemptionMessage] = useState<string | null>(null);
+  const refreshingCodeRef = useRef(false);
+
+  useEffect(() => {
+    void loadAndGenerateCode();
+  }, []);
+
+  useEffect(() => {
+    if (!currentCode) return;
+
+    const interval = setInterval(async () => {
+      const now = new Date();
+      const expiresAt = new Date(currentCode.expiresAt);
+      const diff = expiresAt.getTime() - now.getTime();
+
+      if (diff <= 0) {
+        if (userId) {
+          try {
+            const result = await checkRedemption(userId, currentCode.id);
+            if (result.redeemed) {
+              setCurrentCode(null);
+              setTimeRemaining('');
+              setRedemptionMessage('Redeemed successfully');
+              return;
+            }
+          } catch (error) {
+            console.warn('Final redemption check failed:', error);
+          }
+        }
+
+        setCurrentCode(null);
+        setTimeRemaining('');
+        setMessage('This code expired. Close and tap Scan Card again for a new one.');
+        return;
+      }
+
+      const minutes = Math.floor(diff / 60000);
+      const seconds = Math.floor((diff % 60000) / 1000);
+      setTimeRemaining(`${minutes}:${seconds.toString().padStart(2, '0')}`);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [currentCode, userId]);
+
+  useEffect(() => {
+    if (!currentCode || !userId) return;
+
+    const interval = setInterval(async () => {
+      if (refreshingCodeRef.current) return;
+
+      refreshingCodeRef.current = true;
+      setRefreshingCode(true);
+
+      try {
+        const result = await refreshClaimCode(userId, currentCode.id);
+        if (result.claimCode.status === 'redeemed') {
+          setCurrentCode(null);
+          setTimeRemaining('');
+          setRedemptionMessage('Redeemed successfully');
+          return;
+        }
+
+        setCurrentCode({
+          ...result.claimCode,
+          recommendedRail:
+            result.claimCode.recommendedRail ?? currentCode.recommendedRail ?? 'points-or-bucks',
+          donorDisplayName: result.claimCode.donorDisplayName ?? currentCode.donorDisplayName ?? null,
+        });
+      } catch (error: any) {
+        const errorMessage = error?.message || 'Failed to refresh claim code';
+        console.warn('Claim code refresh failed:', errorMessage);
+
+        if (
+          typeof errorMessage === 'string' &&
+          (errorMessage.includes('expired') || errorMessage.includes('not active'))
+        ) {
+          setCurrentCode(null);
+          setTimeRemaining('');
+          setMessage('This code expired. Close and tap Scan Card again for a new one.');
+        }
+      } finally {
+        refreshingCodeRef.current = false;
+        setRefreshingCode(false);
+      }
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [currentCode, userId]);
+
+  async function loadAndGenerateCode() {
+    setLoading(true);
+    setMessage(null);
+    setRedemptionMessage(null);
+
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        Alert.alert('Error', 'Please sign in first');
+        return;
+      }
+
+      setUserId(user.id);
+      setDisplayName(
+        formatDisplayName(
+          user.email ?? null,
+          typeof user.user_metadata?.full_name === 'string' ? user.user_metadata.full_name : null
+        )
+      );
+
+      const allowance = await getRequesterAllowance(user.id);
+      if (allowance.remainingAmount < DEFAULT_CLAIM_AMOUNT) {
+        setMessage(`You need at least ${DEFAULT_CLAIM_AMOUNT} points remaining to generate a code.`);
+        return;
+      }
+
+      const result = await generateClaimCode(user.id, DEFAULT_CLAIM_AMOUNT);
+      setCurrentCode({
+        ...result.claimCode,
+        recommendedRail: result.claimCode.recommendedRail ?? 'points-or-bucks',
+        donorDisplayName: result.claimCode.donorDisplayName ?? null,
+      });
+    } catch (error: any) {
+      const reason = getClaimFailureReason(error);
+      if (reason === 'pool_exhausted') {
+        setMessage('The shared donor pool is empty right now. Check back later.');
+      } else {
+        console.error('Error generating scan card:', error);
+        setMessage(error?.message || 'Unable to generate a scan card right now.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const activeRail = currentCode?.recommendedRail ?? inferCheckoutRail(undefined);
+  const checkoutLabel =
+    activeRail === 'flexi-dollars' ? 'Flexi Dollars' : 'Slug Points / Banana Bucks';
+
+  return (
+    <View style={styles.screen}>
+      <View style={[styles.topBar, { paddingTop: insets.top + 8 }]}>
+        <Pressable
+          onPress={() => router.back()}
+          style={({ pressed }) => [styles.backButton, { opacity: pressed ? 0.6 : 1 }]}
+        >
+          <SymbolView name="chevron.left" tintColor={colors.text} size={18} />
+          <Text style={styles.backLabel}>Back</Text>
+        </Pressable>
+        <Text style={styles.topBarTitle}>Scan Card</Text>
+        <View style={styles.topBarSpacer} />
+      </View>
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        contentInsetAdjustmentBehavior="never"
+      >
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>UCSC Dining Services</Text>
+          <View style={styles.cardNotch} />
+          <View style={styles.cardBand} />
+
+          <View style={styles.profilePanel}>
+            <SymbolView
+              name="person.crop.circle.badge.questionmark"
+              tintColor="rgba(255,255,255,0.92)"
+              size={118}
+            />
+            <View style={styles.profileNameBar}>
+              <Text style={styles.profileName}>{displayName}</Text>
+            </View>
+          </View>
+
+          <View style={styles.barcodeDock}>
+            {loading ? (
+              <View style={styles.barcodePlaceholder}>
+                <ActivityIndicator size="large" color={colors.brand} />
+              </View>
+            ) : currentCode ? (
+              <PDF417Barcode value={currentCode.code} width={300} height={100} />
+            ) : (
+              <View style={styles.barcodePlaceholder}>
+                <Text style={styles.placeholderText}>{message ?? redemptionMessage ?? 'No active scan card'}</Text>
+              </View>
+            )}
+          </View>
+        </View>
+
+        {currentCode ? (
+          <View style={styles.metaPanel}>
+            <Text selectable style={styles.codeLabel}>
+              {currentCode.code}
+            </Text>
+            <Text style={styles.metaText}>Using {checkoutLabel}</Text>
+            <Text style={styles.metaText}>
+              {currentCode.donorDisplayName
+                ? `Courtesy of ${currentCode.donorDisplayName}`
+                : 'Courtesy of a SlugSwap donor'}
+            </Text>
+            <Text style={styles.metaText}>
+              Expires in {timeRemaining || '0:00'}{refreshingCode ? ' · refreshing' : ''}
+            </Text>
+          </View>
+        ) : null}
+      </ScrollView>
+    </View>
+  );
+}
+
+const colors = stealthTheme.colors;
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#d4d4d4',
+  },
+  topBar: {
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  backButton: {
+    minWidth: 68,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  backLabel: {
+    color: colors.text,
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  topBarTitle: {
+    color: colors.text,
+    fontSize: 18,
+    lineHeight: 24,
+    fontWeight: '600',
+  },
+  topBarSpacer: {
+    width: 68,
+  },
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: 12,
+    paddingTop: 22,
+    paddingBottom: 36,
+  },
+  card: {
+    borderRadius: 22,
+    backgroundColor: colors.brand,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.brandDark,
+    ...cardShadow('hero'),
+  },
+  cardTitle: {
+    paddingTop: 18,
+    paddingBottom: 14,
+    textAlign: 'center',
+    color: '#ffffff',
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: '500',
+  },
+  cardNotch: {
+    position: 'absolute',
+    top: 58,
+    alignSelf: 'center',
+    width: 82,
+    height: 82,
+    backgroundColor: colors.brandDark,
+  },
+  cardBand: {
+    height: 118,
+    backgroundColor: colors.brandDark,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: colors.brandDeeper,
+  },
+  profilePanel: {
+    marginHorizontal: 18,
+    marginTop: 14,
+    height: 360,
+    borderRadius: 24,
+    backgroundColor: '#d7d7d7',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  profileNameBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(135, 135, 135, 0.78)',
+    paddingHorizontal: 22,
+    paddingVertical: 16,
+  },
+  profileName: {
+    color: '#ffffff',
+    fontSize: 22,
+    lineHeight: 28,
+    fontWeight: '400',
+  },
+  barcodeDock: {
+    marginHorizontal: 22,
+    marginTop: 16,
+    marginBottom: 20,
+    minHeight: 126,
+    borderRadius: 16,
+    backgroundColor: '#ffffff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+  },
+  barcodePlaceholder: {
+    minHeight: 110,
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 18,
+  },
+  placeholderText: {
+    ...typeScale.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  metaPanel: {
+    marginTop: 12,
+    borderRadius: 16,
+    padding: 14,
+    backgroundColor: 'rgba(255,255,255,0.88)',
+  },
+  codeLabel: {
+    color: colors.text,
+    fontSize: 13,
+    lineHeight: 18,
+    letterSpacing: 1.8,
+    fontFamily: monoFontFamily,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  metaText: {
+    ...typeScale.caption,
+    color: colors.textMuted,
+    marginBottom: 4,
+  },
+});

--- a/apps/mobile/app/scan-card.tsx
+++ b/apps/mobile/app/scan-card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SymbolView } from 'expo-symbols';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { PDF417Barcode } from '../components/PDF417Barcode';
@@ -78,15 +78,9 @@ function formatDisplayName(email: string | null, fullName?: string | null) {
 
 export default function ScanCardScreen() {
   const router = useRouter();
-  const params = useLocalSearchParams<{ userId?: string; displayName?: string }>();
   const insets = useSafeAreaInsets();
-  const initialDisplayName =
-    typeof params.displayName === 'string' && params.displayName.trim()
-      ? params.displayName
-      : 'Loading...';
-  const initialUserId = typeof params.userId === 'string' && params.userId.trim() ? params.userId : null;
-  const [displayName, setDisplayName] = useState(initialDisplayName);
-  const [userId, setUserId] = useState<string | null>(initialUserId);
+  const [displayName, setDisplayName] = useState('Loading...');
+  const [userId, setUserId] = useState<string | null>(null);
   const [currentCode, setCurrentCode] = useState<ClaimCode | null>(null);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState<string | null>(null);
@@ -110,7 +104,7 @@ export default function ScanCardScreen() {
       if (diff <= 0) {
         if (userId) {
           try {
-            const result = await checkRedemption(userId, currentCode.id);
+            const result = await checkRedemption(currentCode.id);
             if (result.redeemed) {
               setCurrentCode(null);
               setTimeRemaining('');
@@ -146,7 +140,7 @@ export default function ScanCardScreen() {
       setRefreshingCode(true);
 
       try {
-        const result = await refreshClaimCode(userId, currentCode.id);
+        const result = await refreshClaimCode(currentCode.id);
         if (result.claimCode.status === 'redeemed') {
           setCurrentCode(null);
           setTimeRemaining('');
@@ -187,37 +181,26 @@ export default function ScanCardScreen() {
     setRedemptionMessage(null);
 
     try {
-      let resolvedUserId = initialUserId;
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
 
-      if (!resolvedUserId) {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-
-        if (!user) {
-          Alert.alert('Error', 'Please sign in first');
-          return;
-        }
-
-        resolvedUserId = user.id;
-        setDisplayName(
-          formatDisplayName(
-            user.email ?? null,
-            typeof user.user_metadata?.full_name === 'string'
-              ? user.user_metadata.full_name
-              : null
-          )
-        );
-      }
-
-      if (!resolvedUserId) {
+      if (!user) {
         Alert.alert('Error', 'Please sign in first');
         return;
       }
 
-      setUserId(resolvedUserId);
+      setUserId(user.id);
+      setDisplayName(
+        formatDisplayName(
+          user.email ?? null,
+          typeof user.user_metadata?.full_name === 'string'
+            ? user.user_metadata.full_name
+            : null
+        )
+      );
 
-      const result = await generateClaimCode(resolvedUserId, DEFAULT_CLAIM_AMOUNT);
+      const result = await generateClaimCode(DEFAULT_CLAIM_AMOUNT);
       setCurrentCode({
         ...result.claimCode,
         recommendedRail: result.claimCode.recommendedRail ?? 'points-or-bucks',

--- a/apps/mobile/app/scan-card.tsx
+++ b/apps/mobile/app/scan-card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SymbolView } from 'expo-symbols';
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { PDF417Barcode } from '../components/PDF417Barcode';
@@ -9,7 +9,6 @@ import { supabase } from '../../../lib/supabase';
 import {
   checkRedemption,
   generateClaimCode,
-  getRequesterAllowance,
   refreshClaimCode,
   type CheckoutRail,
   type ClaimGenerationFailureReason,
@@ -79,9 +78,15 @@ function formatDisplayName(email: string | null, fullName?: string | null) {
 
 export default function ScanCardScreen() {
   const router = useRouter();
+  const params = useLocalSearchParams<{ userId?: string; displayName?: string }>();
   const insets = useSafeAreaInsets();
-  const [displayName, setDisplayName] = useState('Loading...');
-  const [userId, setUserId] = useState<string | null>(null);
+  const initialDisplayName =
+    typeof params.displayName === 'string' && params.displayName.trim()
+      ? params.displayName
+      : 'Loading...';
+  const initialUserId = typeof params.userId === 'string' && params.userId.trim() ? params.userId : null;
+  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [userId, setUserId] = useState<string | null>(initialUserId);
   const [currentCode, setCurrentCode] = useState<ClaimCode | null>(null);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState<string | null>(null);
@@ -182,30 +187,37 @@ export default function ScanCardScreen() {
     setRedemptionMessage(null);
 
     try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
+      let resolvedUserId = initialUserId;
 
-      if (!user) {
+      if (!resolvedUserId) {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        if (!user) {
+          Alert.alert('Error', 'Please sign in first');
+          return;
+        }
+
+        resolvedUserId = user.id;
+        setDisplayName(
+          formatDisplayName(
+            user.email ?? null,
+            typeof user.user_metadata?.full_name === 'string'
+              ? user.user_metadata.full_name
+              : null
+          )
+        );
+      }
+
+      if (!resolvedUserId) {
         Alert.alert('Error', 'Please sign in first');
         return;
       }
 
-      setUserId(user.id);
-      setDisplayName(
-        formatDisplayName(
-          user.email ?? null,
-          typeof user.user_metadata?.full_name === 'string' ? user.user_metadata.full_name : null
-        )
-      );
+      setUserId(resolvedUserId);
 
-      const allowance = await getRequesterAllowance(user.id);
-      if (allowance.remainingAmount < DEFAULT_CLAIM_AMOUNT) {
-        setMessage(`You need at least ${DEFAULT_CLAIM_AMOUNT} points remaining to generate a code.`);
-        return;
-      }
-
-      const result = await generateClaimCode(user.id, DEFAULT_CLAIM_AMOUNT);
+      const result = await generateClaimCode(resolvedUserId, DEFAULT_CLAIM_AMOUNT);
       setCurrentCode({
         ...result.claimCode,
         recommendedRail: result.claimCode.recommendedRail ?? 'points-or-bucks',

--- a/apps/mobile/components/GetMobileTabBar.tsx
+++ b/apps/mobile/components/GetMobileTabBar.tsx
@@ -1,0 +1,107 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { stealthTheme } from '../lib/stealth-theme';
+
+type NavKey = 'home' | 'accounts' | 'order' | 'explore' | 'more';
+
+type NavItem = {
+  key: NavKey;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  activeIcon?: keyof typeof Ionicons.glyphMap;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { key: 'home', label: 'Home', icon: 'home-outline', activeIcon: 'home' },
+  { key: 'accounts', label: 'Accounts', icon: 'wallet-outline', activeIcon: 'wallet' },
+  { key: 'order', label: 'Order', icon: 'bag-outline', activeIcon: 'bag' },
+  { key: 'explore', label: 'Explore', icon: 'map-outline', activeIcon: 'map' },
+  { key: 'more', label: 'more', icon: 'menu-outline', activeIcon: 'menu' },
+];
+
+const colors = stealthTheme.colors;
+
+export function GetMobileTabBar({
+  active = 'home',
+  onHomePress,
+}: {
+  active?: NavKey;
+  onHomePress?: () => void;
+}) {
+  return (
+    <View style={styles.shell}>
+      <View style={styles.bar}>
+        {NAV_ITEMS.map((item) => {
+          const isActive = item.key === active;
+          const iconName = isActive ? item.activeIcon ?? item.icon : item.icon;
+          const content = (
+            <View style={[styles.item, isActive ? styles.itemActive : null]}>
+              <Ionicons
+                name={iconName}
+                size={26}
+                color={isActive ? colors.accent : colors.textMuted}
+              />
+              <Text style={[styles.label, isActive ? styles.labelActive : null]}>{item.label}</Text>
+            </View>
+          );
+
+          if (item.key === 'home' && onHomePress) {
+            return (
+              <Pressable key={item.key} onPress={onHomePress} style={styles.pressable}>
+                {content}
+              </Pressable>
+            );
+          }
+
+          return (
+            <View key={item.key} style={styles.pressable}>
+              {content}
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  shell: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: colors.surface,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    justifyContent: 'space-between',
+    minHeight: 78,
+  },
+  pressable: {
+    flex: 1,
+  },
+  item: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 3,
+    paddingTop: 8,
+    paddingBottom: 9,
+  },
+  itemActive: {
+    backgroundColor: colors.accentMuted,
+  },
+  label: {
+    fontSize: 11,
+    lineHeight: 14,
+    color: colors.textMuted,
+    fontWeight: '500',
+  },
+  labelActive: {
+    color: colors.accent,
+  },
+});

--- a/apps/mobile/components/PDF417Barcode.tsx
+++ b/apps/mobile/components/PDF417Barcode.tsx
@@ -1,5 +1,6 @@
 import { View, StyleSheet } from 'react-native';
 import RNPDF417 from 'expo-barcode-pdf417';
+import { cardShadow, stealthTheme } from '../lib/stealth-theme';
 
 interface PDF417BarcodeProps {
   value: string;
@@ -24,8 +25,13 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: 'white',
-    borderRadius: 8,
+    backgroundColor: stealthTheme.colors.barcode,
+    borderRadius: stealthTheme.radii.sm,
+    borderWidth: 1,
+    borderColor: stealthTheme.colors.borderStrong,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
     overflow: 'hidden',
+    ...cardShadow(),
   },
 });

--- a/apps/mobile/lib/stealth-theme.ts
+++ b/apps/mobile/lib/stealth-theme.ts
@@ -1,0 +1,117 @@
+import { Platform } from 'react-native';
+import type { TextStyle, ViewStyle } from 'react-native';
+
+const palette = {
+  canvas: '#eef2f5',
+  canvasAlt: '#e6edf2',
+  surface: '#ffffff',
+  surfaceMuted: '#f4f6f8',
+  surfaceStrong: '#e9eef2',
+  brand: '#0f73af',
+  brandDark: '#0a5e93',
+  brandDeeper: '#0a4d7c',
+  brandInk: '#084a78',
+  accent: '#2f70f4',
+  accentMuted: '#dfe9ff',
+  success: '#1f8f64',
+  warning: '#d4831f',
+  danger: '#c95151',
+  text: '#121821',
+  textMuted: '#5e6a76',
+  textSoft: '#86919c',
+  border: '#d6dfe6',
+  borderStrong: '#c4d1db',
+  barcode: '#ffffff',
+  shadow: '#082236',
+  overlay: 'rgba(8, 34, 54, 0.16)',
+};
+
+const radii = {
+  xs: 10,
+  sm: 14,
+  md: 18,
+  lg: 24,
+  pill: 999,
+};
+
+export const stealthTheme = {
+  colors: palette,
+  radii,
+  spacing: {
+    xs: 8,
+    sm: 12,
+    md: 16,
+    lg: 20,
+    xl: 24,
+  },
+};
+
+export const monoFontFamily = Platform.select({
+  ios: 'Menlo',
+  android: 'monospace',
+  default: 'monospace',
+});
+
+function iosShadow(opacity: number, radius: number, height: number): ViewStyle {
+  return {
+    shadowColor: palette.shadow,
+    shadowOpacity: opacity,
+    shadowRadius: radius,
+    shadowOffset: { width: 0, height },
+  };
+}
+
+export function cardShadow(level: 'surface' | 'hero' = 'surface'): ViewStyle {
+  if (Platform.OS === 'android') {
+    return {
+      elevation: level === 'hero' ? 8 : 4,
+      shadowColor: palette.shadow,
+    };
+  }
+
+  return level === 'hero' ? iosShadow(0.22, 18, 10) : iosShadow(0.12, 12, 6);
+}
+
+export function buttonOpacity(pressed: boolean, disabled = false): number {
+  if (disabled) return 0.55;
+  return pressed ? 0.82 : 1;
+}
+
+export const typeScale: Record<
+  'eyebrow' | 'title' | 'headline' | 'body' | 'caption' | 'metric',
+  TextStyle
+> = {
+  eyebrow: {
+    fontSize: 12,
+    lineHeight: 16,
+    fontWeight: '600',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+  },
+  title: {
+    fontSize: 18,
+    lineHeight: 24,
+    fontWeight: '700',
+  },
+  headline: {
+    fontSize: 34,
+    lineHeight: 40,
+    fontWeight: '700',
+  },
+  body: {
+    fontSize: 15,
+    lineHeight: 21,
+    fontWeight: '500',
+  },
+  caption: {
+    fontSize: 13,
+    lineHeight: 18,
+    fontWeight: '500',
+  },
+  metric: {
+    fontSize: 36,
+    lineHeight: 40,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -104,6 +104,11 @@ async function fetchWithFallback(url: string, init?: RequestInit): Promise<Respo
 
 if (__DEV__) {
   console.log('Resolved API_BASE_URL:', API_BASE_URL);
+  if (/^https?:\/\/(localhost|127\.0\.0\.1|192\.168\.|10\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(API_BASE_URL)) {
+    console.log('Using local API backend:', API_BASE_URL);
+  } else {
+    console.log('Using remote API backend:', API_BASE_URL);
+  }
 }
 
 export type DonorImpact = {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -266,11 +266,12 @@ export async function getRequesterAllowance(userId: string) {
   return response.json();
 }
 
-export async function generateClaimCode(userId: string, amount: number) {
+export async function generateClaimCode(amount: number) {
+  const headers = await getAuthHeaders();
   const response = await fetchWithFallback(`${API_BASE_URL}/api/claims/generate`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, amount }),
+    headers,
+    body: JSON.stringify({ amount }),
   });
 
   if (!response.ok) {
@@ -283,8 +284,11 @@ export async function generateClaimCode(userId: string, amount: number) {
   return response.json() as Promise<{ success: boolean; claimCode: ClaimCodePayload }>;
 }
 
-export async function getClaimHistory(userId: string) {
-  const response = await fetchWithFallback(`${API_BASE_URL}/api/claims/history?userId=${userId}`);
+export async function getClaimHistory() {
+  const headers = await getAuthHeaders();
+  const response = await fetchWithFallback(`${API_BASE_URL}/api/claims/history`, {
+    headers,
+  });
 
   if (!response.ok) {
     const errorMessage = await readApiError(response, 'Failed to fetch claim history');
@@ -294,11 +298,12 @@ export async function getClaimHistory(userId: string) {
   return response.json();
 }
 
-export async function refreshClaimCode(userId: string, claimCodeId: string) {
+export async function refreshClaimCode(claimCodeId: string) {
+  const headers = await getAuthHeaders();
   const response = await fetchWithFallback(`${API_BASE_URL}/api/claims/refresh`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, claimCodeId }),
+    headers,
+    body: JSON.stringify({ claimCodeId }),
   });
 
   if (!response.ok) {
@@ -312,11 +317,12 @@ export async function refreshClaimCode(userId: string, claimCodeId: string) {
   }>;
 }
 
-export async function checkRedemption(userId: string, claimCodeId: string) {
+export async function checkRedemption(claimCodeId: string) {
+  const headers = await getAuthHeaders();
   const response = await fetchWithFallback(`${API_BASE_URL}/api/claims/check-redemption`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, claimCodeId }),
+    headers,
+    body: JSON.stringify({ claimCodeId }),
   });
 
   if (!response.ok) {
@@ -331,11 +337,12 @@ export async function checkRedemption(userId: string, claimCodeId: string) {
   }>;
 }
 
-export async function deleteClaimCode(userId: string, claimCodeId: string) {
+export async function deleteClaimCode(claimCodeId: string) {
+  const headers = await getAuthHeaders();
   const response = await fetchWithFallback(`${API_BASE_URL}/api/claims/delete`, {
     method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, claimCodeId }),
+    headers,
+    body: JSON.stringify({ claimCodeId }),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- make the GET-inspired mobile skin the default across the app shell, share screen, request flow, and auth surfaces
- replace the scan action with a dedicated GET-style scan card modal and static GET-like bottom navigation treatment
- speed up and stabilize scan card generation by passing donor identity directly, adding claim-generation timing logs, and bootstrapping missing weekly pool and allowance records in the claims API

## Testing
- npm run mobile:typecheck
- npm run dashboard:typecheck