### PR TITLE
Add reliable donor spend notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ ADMIN_EMAIL_ALLOWLIST=<email of google account for admin dashboard>
 ADMIN_SESSION_SECRET=<strong-random-session-signing-secret>
 REVALIDATE_SECRET=<strong-random-revalidation-secret>
 
+# Server-side Expo push delivery and authenticated Vercel recovery cron
+EXPO_ACCESS_TOKEN=
+CRON_SECRET=<strong-random-cron-secret>
+
 # Comma-, semicolon-, or whitespace-separated production client origins
 CORS_ALLOWED_ORIGINS=https://slugswap.vercel.app
 

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -19,5 +19,9 @@ ADMIN_EMAIL_ALLOWLIST=<comma-separated-admin-emails>
 ADMIN_SESSION_SECRET=<strong-random-session-signing-secret>
 REVALIDATE_SECRET=<strong-random-revalidation-secret>
 
+# Server-side Expo push delivery and authenticated Vercel recovery cron
+EXPO_ACCESS_TOKEN=
+CRON_SECRET=<strong-random-cron-secret>
+
 # Comma-, semicolon-, or whitespace-separated production client origins
 CORS_ALLOWED_ORIGINS=https://slugswap.vercel.app

--- a/apps/dashboard/app/admin-dashboard-client.tsx
+++ b/apps/dashboard/app/admin-dashboard-client.tsx
@@ -33,6 +33,8 @@ type PoolConfig = {
   androidRequiredVersion: string;
   iosStoreUrl: string | null;
   androidStoreUrl: string | null;
+  donorSpendNotificationTitle: string;
+  donorSpendNotificationBody: string;
 };
 
 type NumericConfigField =
@@ -47,7 +49,9 @@ type TextConfigField =
   | "iosRequiredVersion"
   | "androidRequiredVersion"
   | "iosStoreUrl"
-  | "androidStoreUrl";
+  | "androidStoreUrl"
+  | "donorSpendNotificationTitle"
+  | "donorSpendNotificationBody";
 
 type AdminStatsResponse = {
   timestamp: string;
@@ -622,6 +626,8 @@ export default function DashboardHomePage() {
       androidRequiredVersion: configDraft.androidRequiredVersion.trim(),
       iosStoreUrl: configDraft.iosStoreUrl?.trim() || null,
       androidStoreUrl: configDraft.androidStoreUrl?.trim() || null,
+      donorSpendNotificationTitle: configDraft.donorSpendNotificationTitle.trim(),
+      donorSpendNotificationBody: configDraft.donorSpendNotificationBody.trim(),
     };
 
     setIsSaving(true);
@@ -1882,6 +1888,53 @@ export default function DashboardHomePage() {
                           placeholder="https://play.google.com/store/apps/details?id=..."
                         />
                       </div>
+                    </div>
+
+                    <div className="config-item">
+                      <label className="config-label" htmlFor="cfg-donor-notification-title">
+                        Donor Spend Notification Title
+                      </label>
+                      <div className="config-input-wrap">
+                        <input
+                          id="cfg-donor-notification-title"
+                          className="config-input"
+                          type="text"
+                          maxLength={100}
+                          value={configDraft?.donorSpendNotificationTitle ?? ""}
+                          onChange={(event) =>
+                            handleConfigTextChange(
+                              "donorSpendNotificationTitle",
+                              event.target.value
+                            )
+                          }
+                          placeholder="Your SlugPoints helped someone"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="config-item" style={{ gridColumn: "1 / -1" }}>
+                      <label className="config-label" htmlFor="cfg-donor-notification-body">
+                        Donor Spend Notification Message
+                      </label>
+                      <textarea
+                        id="cfg-donor-notification-body"
+                        className="config-input"
+                        maxLength={500}
+                        rows={3}
+                        value={configDraft?.donorSpendNotificationBody ?? ""}
+                        onChange={(event) =>
+                          handleConfigTextChange(
+                            "donorSpendNotificationBody",
+                            event.target.value
+                          )
+                        }
+                        placeholder="Someone just spent {{amount}} of the SlugPoints you donated."
+                        style={{ minHeight: 92, resize: "vertical" }}
+                      />
+                      <span className="config-label" style={{ marginTop: 8 }}>
+                        Use {"{{amount}}"} to insert the exact number of points spent. Without it,
+                        the message is sent exactly as written.
+                      </span>
                     </div>
                   </div>
                   <p

--- a/apps/dashboard/app/api-query-section.tsx
+++ b/apps/dashboard/app/api-query-section.tsx
@@ -63,6 +63,9 @@ const API_ENDPOINTS: ApiEndpoint[] = [
         androidRequiredVersion: "1.0.0",
         iosStoreUrl: "https://testflight.apple.com/join/<code>",
         androidStoreUrl: "https://play.google.com/store/apps/details?id=<package>",
+        donorSpendNotificationTitle: "Your SlugPoints helped someone",
+        donorSpendNotificationBody:
+          "Someone just spent {{amount}} of your donated SlugPoints. Thank you for sharing!",
       },
       null,
       2
@@ -115,6 +118,24 @@ const API_ENDPOINTS: ApiEndpoint[] = [
     description: "Pause or resume donor",
     requiresAuth: true,
     bodyExample: JSON.stringify({ paused: true }, null, 2),
+  },
+  {
+    path: "/api/notifications/register",
+    method: "POST",
+    description: "Register an Expo push token for the authenticated app user",
+    requiresAuth: true,
+    bodyExample: JSON.stringify(
+      { token: "ExponentPushToken[...]", platform: "ios" },
+      null,
+      2
+    ),
+  },
+  {
+    path: "/api/notifications/preference",
+    method: "PATCH",
+    description: "Enable or disable donor spend notifications",
+    requiresAuth: true,
+    bodyExample: JSON.stringify({ enabled: true }, null, 2),
   },
   // GET (school point system)
   { path: "/api/get/login-url", method: "GET", description: "GET Tools login URL", requiresAuth: false },

--- a/apps/dashboard/app/api/admin/[action]/route.ts
+++ b/apps/dashboard/app/api/admin/[action]/route.ts
@@ -240,7 +240,7 @@ async function dispatch(req: NextRequest, ctx: Ctx) {
         const message = error?.message || "Internal server error";
         const status =
           typeof message === "string" &&
-          (message.startsWith("Invalid value") || message.includes("must be"))
+          (message.startsWith("Invalid value") || message.includes("must "))
             ? 400
             : 500;
         return NextResponse.json(

--- a/apps/dashboard/app/api/claims/[action]/route.ts
+++ b/apps/dashboard/app/api/claims/[action]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { and, asc, desc, eq, gte, lt, lte, sql as sqlOp } from "drizzle-orm";
+import { waitUntil } from "@vercel/functions";
 import {
   authenticateAppUser,
   syncAuthenticatedUser,
@@ -21,8 +22,10 @@ import {
   getPacificDayWindow,
 } from "@/lib/server/timezone";
 import { getOrCreateCurrentWeeklyPool } from "@/lib/server/weekly-pool";
+import { runDonorSpendDeliveryPipeline } from "@/lib/server/notifications/donor-spend";
 
 export const runtime = "nodejs";
+export const maxDuration = 300;
 
 type Ctx = { params: Promise<{ action: string }> };
 type CheckoutRail = "points-or-bucks" | "flexi-dollars";
@@ -31,6 +34,14 @@ type ClaimGenerationFailureReason =
   | "allowance_exhausted"
   | "pool_exhausted"
   | "pool_unavailable";
+
+function scheduleDonorSpendNotification(claimCodeId: string) {
+  waitUntil(
+    runDonorSpendDeliveryPipeline(claimCodeId).catch((error) => {
+      console.error("Donor spend notification pipeline failed", { claimCodeId, error });
+    })
+  );
+}
 
 const FLEXI_ACCOUNT_NAME = "flexi dollars";
 const POINTS_OR_BUCKS_ACCOUNT_NAMES = new Set(["banana bucks", "slug points"]);
@@ -891,6 +902,16 @@ async function detectRedemption(
         .join(",")}`,
     });
 
+    await tx
+      .insert(schema.notificationDeliveries)
+      .values({
+        claimCodeId: claim.id,
+        donorUserId: claim.donorUserId!,
+        kind: "donor_spend",
+        status: "pending",
+      })
+      .onConflictDoNothing({ target: schema.notificationDeliveries.claimCodeId });
+
     const userAllowance = await tx
       .select({ id: schema.userAllowances.id })
       .from(schema.userAllowances)
@@ -917,6 +938,10 @@ async function detectRedemption(
 
     return true;
   });
+
+  if (didRedeem) {
+    scheduleDonorSpendNotification(claim.id);
+  }
 
   return didRedeem
     ? {
@@ -971,6 +996,7 @@ async function handleCheckRedemption(req: NextRequest) {
     const currentClaim = claim[0];
 
     if (currentClaim.status === "redeemed") {
+      scheduleDonorSpendNotification(currentClaim.id);
       return NextResponse.json(
         { redeemed: true, amount: parseFloat(currentClaim.amount) },
         { status: 200 }

--- a/apps/dashboard/app/api/cron/notifications/route.ts
+++ b/apps/dashboard/app/api/cron/notifications/route.ts
@@ -1,0 +1,27 @@
+import { processDonorSpendNotificationQueue } from "@/lib/server/notifications/donor-spend";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+export async function GET(request: Request) {
+  const cronSecret = process.env.CRON_SECRET?.trim();
+  if (!cronSecret) {
+    return Response.json({ error: "CRON_SECRET is not configured" }, { status: 500 });
+  }
+
+  if (request.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await processDonorSpendNotificationQueue();
+    return Response.json({
+      ok: true,
+      ...result,
+      processedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Notification recovery cron failed", error);
+    return Response.json({ error: "Notification recovery failed" }, { status: 500 });
+  }
+}

--- a/apps/dashboard/app/api/donations/[action]/route.ts
+++ b/apps/dashboard/app/api/donations/[action]/route.ts
@@ -140,6 +140,7 @@ async function handleImpact(req: NextRequest) {
       return NextResponse.json(
         {
           isActive: false,
+          notifyOnSpend: false,
           weeklyAmount: 0,
           status: "paused",
           peopleHelped: 0,
@@ -249,6 +250,7 @@ async function handleImpact(req: NextRequest) {
     return NextResponse.json(
       {
         isActive: donation.status === "active",
+        notifyOnSpend: donation.notifyOnSpend,
         weeklyAmount,
         status: donation.status,
         peopleHelped: Number(peopleHelped[0]?.count ?? 0),

--- a/apps/dashboard/app/api/mobile/home/route.ts
+++ b/apps/dashboard/app/api/mobile/home/route.ts
@@ -41,6 +41,7 @@ function emptyImpact() {
   const weekWindow = getPacificWeekWindow();
   return {
     isActive: false,
+    notifyOnSpend: false,
     weeklyAmount: 0,
     status: "paused",
     peopleHelped: 0,
@@ -296,6 +297,7 @@ async function getImpactForUser(userId: string) {
 
   return {
     isActive: donation.status === "active",
+    notifyOnSpend: donation.notifyOnSpend,
     weeklyAmount,
     status: donation.status,
     peopleHelped: Number(peopleHelped[0]?.count ?? 0),

--- a/apps/dashboard/app/api/notifications/[action]/route.ts
+++ b/apps/dashboard/app/api/notifications/[action]/route.ts
@@ -1,0 +1,189 @@
+import { and, eq, sql } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  authenticateAppUser,
+  syncAuthenticatedUser,
+} from "@/lib/server/app-user-auth";
+import { db } from "@/lib/server/db";
+import * as schema from "@/lib/server/schema";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ action: string }> };
+type PushPlatform = "ios" | "android";
+
+function isExpoPushToken(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^(?:Exponent|Expo)PushToken\[[A-Za-z0-9_-]+]$/.test(value) &&
+    value.length <= 200
+  );
+}
+
+function isPushPlatform(value: unknown): value is PushPlatform {
+  return value === "ios" || value === "android";
+}
+
+async function authenticate(req: NextRequest) {
+  const auth = await authenticateAppUser(req);
+  if ("response" in auth) return auth;
+  await syncAuthenticatedUser(auth.user);
+  return auth;
+}
+
+async function handleRegister(req: NextRequest) {
+  if (req.method !== "POST") {
+    return NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const auth = await authenticate(req);
+  if ("response" in auth) return auth.response;
+
+  const { token, platform } = (await req.json()) as {
+    token?: unknown;
+    platform?: unknown;
+  };
+  if (!isExpoPushToken(token)) {
+    return NextResponse.json({ error: "Invalid Expo push token" }, { status: 400 });
+  }
+  if (!isPushPlatform(platform)) {
+    return NextResponse.json({ error: "platform must be ios or android" }, { status: 400 });
+  }
+
+  const now = new Date();
+  await db
+    .insert(schema.pushTokens)
+    .values({
+      token,
+      userId: auth.user.id,
+      platform,
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: schema.pushTokens.token,
+      set: {
+        userId: auth.user.id,
+        platform,
+        enabled: true,
+        updatedAt: now,
+      },
+    });
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}
+
+async function handleUnregister(req: NextRequest) {
+  if (req.method !== "DELETE") {
+    return NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const auth = await authenticate(req);
+  if ("response" in auth) return auth.response;
+  const { token } = (await req.json()) as { token?: unknown };
+  if (!isExpoPushToken(token)) {
+    return NextResponse.json({ error: "Invalid Expo push token" }, { status: 400 });
+  }
+
+  await db
+    .update(schema.pushTokens)
+    .set({ enabled: false, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.pushTokens.token, token),
+        eq(schema.pushTokens.userId, auth.user.id)
+      )
+    );
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}
+
+async function handlePreference(req: NextRequest) {
+  const auth = await authenticate(req);
+  if ("response" in auth) return auth.response;
+
+  if (req.method === "GET") {
+    const [donation, tokenCount] = await Promise.all([
+      db
+        .select({ notifyOnSpend: schema.donations.notifyOnSpend })
+        .from(schema.donations)
+        .where(eq(schema.donations.userId, auth.user.id))
+        .limit(1),
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(schema.pushTokens)
+        .where(
+          and(
+            eq(schema.pushTokens.userId, auth.user.id),
+            eq(schema.pushTokens.enabled, true)
+          )
+        ),
+    ]);
+
+    return NextResponse.json(
+      {
+        notifyOnSpend: donation[0]?.notifyOnSpend ?? false,
+        registeredDeviceCount: Number(tokenCount[0]?.count ?? 0),
+      },
+      { status: 200 }
+    );
+  }
+
+  if (req.method !== "PATCH") {
+    return NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const { enabled } = (await req.json()) as { enabled?: unknown };
+  if (typeof enabled !== "boolean") {
+    return NextResponse.json({ error: "enabled must be a boolean" }, { status: 400 });
+  }
+
+  const [updated] = await db
+    .update(schema.donations)
+    .set({ notifyOnSpend: enabled, updatedAt: new Date() })
+    .where(eq(schema.donations.userId, auth.user.id))
+    .returning({ notifyOnSpend: schema.donations.notifyOnSpend });
+
+  if (!updated) {
+    return NextResponse.json({ error: "Donation not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(
+    { success: true, notifyOnSpend: updated.notifyOnSpend },
+    { status: 200 }
+  );
+}
+
+async function dispatch(req: NextRequest, ctx: Ctx) {
+  try {
+    const { action } = await ctx.params;
+    if (action === "register") return handleRegister(req);
+    if (action === "unregister") return handleUnregister(req);
+    if (action === "preference") return handlePreference(req);
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  } catch (error) {
+    console.error("Notification API error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(req: NextRequest, ctx: Ctx) {
+  return dispatch(req, ctx);
+}
+
+export async function POST(req: NextRequest, ctx: Ctx) {
+  return dispatch(req, ctx);
+}
+
+export async function PATCH(req: NextRequest, ctx: Ctx) {
+  return dispatch(req, ctx);
+}
+
+export async function DELETE(req: NextRequest, ctx: Ctx) {
+  return dispatch(req, ctx);
+}

--- a/apps/dashboard/lib/server/config.ts
+++ b/apps/dashboard/lib/server/config.ts
@@ -23,6 +23,8 @@ export type AdminConfig = {
   androidRequiredVersion: string;
   iosStoreUrl: string | null;
   androidStoreUrl: string | null;
+  donorSpendNotificationTitle: string;
+  donorSpendNotificationBody: string;
 };
 
 export const DEFAULT_ADMIN_CONFIG: AdminConfig = {
@@ -38,6 +40,9 @@ export const DEFAULT_ADMIN_CONFIG: AdminConfig = {
   androidRequiredVersion: "1.0.0",
   iosStoreUrl: null,
   androidStoreUrl: null,
+  donorSpendNotificationTitle: "Your SlugPoints helped someone",
+  donorSpendNotificationBody:
+    "Someone just spent {{amount}} of your donated SlugPoints. Thank you for sharing!",
 };
 
 const ADMIN_CONFIG_ID = "global";
@@ -127,6 +132,17 @@ function normalizeOptionalUrl(field: string, value: unknown): string | null {
   }
 }
 
+function normalizeNotificationText(field: string, value: unknown, maxLength: number): string {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) {
+    throw new Error(`${field} must not be empty`);
+  }
+  if (trimmed.length > maxLength) {
+    throw new Error(`${field} must be ${maxLength} characters or fewer`);
+  }
+  return trimmed;
+}
+
 function rowToConfig(row: typeof adminConfig.$inferSelect): AdminConfig {
   return {
     defaultWeeklyAllowance: row.defaultWeeklyAllowance,
@@ -144,6 +160,16 @@ function rowToConfig(row: typeof adminConfig.$inferSelect): AdminConfig {
     ),
     iosStoreUrl: normalizeOptionalUrl("iosStoreUrl", row.iosStoreUrl),
     androidStoreUrl: normalizeOptionalUrl("androidStoreUrl", row.androidStoreUrl),
+    donorSpendNotificationTitle: normalizeNotificationText(
+      "donorSpendNotificationTitle",
+      row.donorSpendNotificationTitle,
+      100
+    ),
+    donorSpendNotificationBody: normalizeNotificationText(
+      "donorSpendNotificationBody",
+      row.donorSpendNotificationBody,
+      500
+    ),
   };
 }
 
@@ -173,6 +199,13 @@ async function loadAdminConfigFromDb(): Promise<{ config: AdminConfig; updatedAt
     config: rowToConfig(row),
     updatedAt: row.updatedAt,
   };
+}
+
+export async function getAdminConfigUncached(): Promise<{
+  config: AdminConfig;
+  updatedAt: Date;
+}> {
+  return loadAdminConfigFromDb();
 }
 
 const getCachedAdminConfig = unstable_cache(
@@ -280,6 +313,22 @@ export async function updateAdminConfig(
     );
   }
 
+  if (updates.donorSpendNotificationTitle !== undefined) {
+    merged.donorSpendNotificationTitle = normalizeNotificationText(
+      "donorSpendNotificationTitle",
+      updates.donorSpendNotificationTitle,
+      100
+    );
+  }
+
+  if (updates.donorSpendNotificationBody !== undefined) {
+    merged.donorSpendNotificationBody = normalizeNotificationText(
+      "donorSpendNotificationBody",
+      updates.donorSpendNotificationBody,
+      500
+    );
+  }
+
   validateConfigRelationships(merged);
 
   const [saved] = await db
@@ -304,6 +353,8 @@ export async function updateAdminConfig(
         androidRequiredVersion: merged.androidRequiredVersion,
         iosStoreUrl: merged.iosStoreUrl,
         androidStoreUrl: merged.androidStoreUrl,
+        donorSpendNotificationTitle: merged.donorSpendNotificationTitle,
+        donorSpendNotificationBody: merged.donorSpendNotificationBody,
         updatedAt: new Date(),
       },
     })

--- a/apps/dashboard/lib/server/notifications/donor-spend.ts
+++ b/apps/dashboard/lib/server/notifications/donor-spend.ts
@@ -1,0 +1,534 @@
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
+
+import { getAdminConfigUncached } from "@/lib/server/config";
+import { db } from "@/lib/server/db";
+import * as schema from "@/lib/server/schema";
+import {
+  buildExpoPushMessages,
+  parseExpoPushTickets,
+  renderDonorSpendTemplate,
+  serializeExpoPushTickets,
+  summarizeExpoPushReceipts,
+  summarizeExpoPushTickets,
+  type ExpoPushReceiptSummary,
+  type ExpoPushTicket,
+} from "./template";
+
+const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
+const EXPO_RECEIPTS_URL = "https://exp.host/--/api/v2/push/getReceipts";
+const EXPO_PUSH_CHUNK_SIZE = 100;
+const EXPO_RECEIPT_CHUNK_SIZE = 1_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+const REQUEST_MAX_ATTEMPTS = 3;
+const DELIVERY_MAX_ATTEMPTS = 8;
+const STALE_PROCESSING_MS = 2 * 60 * 1000;
+const RECEIPT_RECHECK_MS = 60 * 1000;
+const RECEIPT_MAX_WAIT_MS = 23 * 60 * 60 * 1000;
+const PIPELINE_RECEIPT_DELAYS_MS = [5_000, 20_000, 60_000, 120_000] as const;
+const QUEUE_SCAN_MULTIPLIER = 5;
+
+type NotificationDelivery = typeof schema.notificationDeliveries.$inferSelect;
+
+export type DonorSpendDeliveryResult =
+  | "submitted"
+  | "skipped"
+  | "failed"
+  | "already_processed"
+  | "not_found";
+
+export type DonorSpendReceiptResult =
+  | "sent"
+  | "failed"
+  | "waiting"
+  | "already_processing"
+  | "not_found";
+
+export type NotificationQueueResult = {
+  processed: number;
+  results: Record<string, number>;
+};
+
+class ExpoRequestError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean
+  ) {
+    super(message);
+    this.name = "ExpoRequestError";
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function chunkValues<T>(values: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+  return chunks;
+}
+
+function expoHeaders(): Record<string, string> {
+  const accessToken = process.env.EXPO_ACCESS_TOKEN?.trim();
+  return {
+    Accept: "application/json",
+    "Accept-Encoding": "gzip, deflate",
+    "Content-Type": "application/json",
+    ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+  };
+}
+
+async function postExpoJson(url: string, body: unknown): Promise<unknown> {
+  let lastError: unknown = new Error("Expo request failed");
+
+  for (let attempt = 0; attempt < REQUEST_MAX_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: expoHeaders(),
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const responseBody = await response.text().catch(() => "");
+        throw new ExpoRequestError(
+          `Expo API returned ${response.status}${responseBody ? `: ${responseBody.slice(0, 300)}` : ""}`,
+          response.status === 429 || response.status >= 500
+        );
+      }
+
+      return await response.json();
+    } catch (error) {
+      lastError = error;
+      const retryable = !(error instanceof ExpoRequestError) || error.retryable;
+      if (!retryable || attempt === REQUEST_MAX_ATTEMPTS - 1) {
+        throw error;
+      }
+      await sleep(1_000 * 2 ** attempt);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  throw lastError;
+}
+
+async function postExpoPushNotifications(
+  tokens: string[],
+  title: string,
+  body: string,
+  claimCodeId: string
+): Promise<ReturnType<typeof summarizeExpoPushTickets>> {
+  const summary: ReturnType<typeof summarizeExpoPushTickets> = {
+    errors: [],
+    successfulTickets: [],
+    unregisteredTokens: [],
+  };
+
+  for (const tokenChunk of chunkValues(tokens, EXPO_PUSH_CHUNK_SIZE)) {
+    const payload = await postExpoJson(
+      EXPO_PUSH_URL,
+      buildExpoPushMessages(tokenChunk, title, body, claimCodeId)
+    );
+    const chunkSummary = summarizeExpoPushTickets(payload, tokenChunk);
+    summary.errors.push(...chunkSummary.errors);
+    summary.successfulTickets.push(...chunkSummary.successfulTickets);
+    summary.unregisteredTokens.push(...chunkSummary.unregisteredTokens);
+  }
+
+  return summary;
+}
+
+async function postExpoPushReceipts(
+  tickets: ExpoPushTicket[]
+): Promise<ExpoPushReceiptSummary> {
+  const summary: ExpoPushReceiptSummary = {
+    errors: [],
+    isValid: true,
+    pendingTicketIds: [],
+    successfulTicketIds: [],
+    unregisteredTokens: [],
+  };
+
+  for (const ticketChunk of chunkValues(tickets, EXPO_RECEIPT_CHUNK_SIZE)) {
+    const payload = await postExpoJson(EXPO_RECEIPTS_URL, {
+      ids: ticketChunk.map(({ id }) => id),
+    });
+    const chunkSummary = summarizeExpoPushReceipts(payload, ticketChunk);
+    summary.errors.push(...chunkSummary.errors);
+    summary.isValid = summary.isValid && chunkSummary.isValid;
+    summary.pendingTicketIds.push(...chunkSummary.pendingTicketIds);
+    summary.successfulTicketIds.push(...chunkSummary.successfulTicketIds);
+    summary.unregisteredTokens.push(...chunkSummary.unregisteredTokens);
+  }
+
+  return summary;
+}
+
+async function disablePushTokens(tokens: string[]): Promise<void> {
+  if (tokens.length === 0) return;
+  await db
+    .update(schema.pushTokens)
+    .set({ enabled: false, updatedAt: new Date() })
+    .where(inArray(schema.pushTokens.token, [...new Set(tokens)]));
+}
+
+async function finishDelivery(
+  deliveryId: string,
+  status: "sent" | "failed" | "skipped",
+  values: {
+    title?: string;
+    body?: string;
+    expoTicketIds?: string | null;
+    lastError?: string | null;
+    submittedAt?: Date | null;
+    sentAt?: Date | null;
+  } = {}
+): Promise<void> {
+  await db
+    .update(schema.notificationDeliveries)
+    .set({
+      status,
+      ...values,
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.notificationDeliveries.id, deliveryId));
+}
+
+async function returnToSubmitted(
+  deliveryId: string,
+  lastError: string | null
+): Promise<void> {
+  await db
+    .update(schema.notificationDeliveries)
+    .set({
+      status: "submitted",
+      lastError,
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.notificationDeliveries.id, deliveryId));
+}
+
+function existingDeliveryResult(
+  delivery: Pick<NotificationDelivery, "status" | "expoTicketIds"> | undefined
+): DonorSpendDeliveryResult {
+  if (!delivery) return "not_found";
+  if (delivery.status === "submitted" || (delivery.status === "sending" && delivery.expoTicketIds)) {
+    return "submitted";
+  }
+  return "already_processed";
+}
+
+export async function deliverDonorSpendNotification(
+  claimCodeId: string
+): Promise<DonorSpendDeliveryResult> {
+  const now = new Date();
+  const staleProcessingBefore = new Date(now.getTime() - STALE_PROCESSING_MS);
+  const [delivery] = await db
+    .update(schema.notificationDeliveries)
+    .set({
+      status: "sending",
+      attemptCount: sql`${schema.notificationDeliveries.attemptCount} + 1`,
+      expoTicketIds: null,
+      lastError: null,
+      submittedAt: null,
+      sentAt: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.notificationDeliveries.claimCodeId, claimCodeId),
+        lt(schema.notificationDeliveries.attemptCount, DELIVERY_MAX_ATTEMPTS),
+        or(
+          inArray(schema.notificationDeliveries.status, ["pending", "failed"]),
+          and(
+            eq(schema.notificationDeliveries.status, "sending"),
+            isNull(schema.notificationDeliveries.expoTicketIds),
+            lt(schema.notificationDeliveries.updatedAt, staleProcessingBefore)
+          )
+        )
+      )
+    )
+    .returning();
+
+  if (!delivery) {
+    const existing = await db
+      .select({
+        status: schema.notificationDeliveries.status,
+        expoTicketIds: schema.notificationDeliveries.expoTicketIds,
+      })
+      .from(schema.notificationDeliveries)
+      .where(eq(schema.notificationDeliveries.claimCodeId, claimCodeId))
+      .limit(1);
+    return existingDeliveryResult(existing[0]);
+  }
+
+  try {
+    const claimRows = await db
+      .select({
+        amount: schema.claimCodes.amount,
+        donorUserId: schema.claimCodes.donorUserId,
+        notifyOnSpend: schema.donations.notifyOnSpend,
+      })
+      .from(schema.claimCodes)
+      .leftJoin(
+        schema.donations,
+        eq(schema.donations.userId, schema.claimCodes.donorUserId)
+      )
+      .where(eq(schema.claimCodes.id, claimCodeId))
+      .limit(1);
+    const claim = claimRows[0];
+
+    if (!claim?.donorUserId || claim.notifyOnSpend !== true) {
+      await finishDelivery(delivery.id, "skipped", {
+        lastError: "Donor spend notifications are disabled",
+      });
+      return "skipped";
+    }
+
+    const tokens = await db
+      .select({ token: schema.pushTokens.token })
+      .from(schema.pushTokens)
+      .where(
+        and(
+          eq(schema.pushTokens.userId, claim.donorUserId),
+          eq(schema.pushTokens.enabled, true)
+        )
+      );
+
+    if (tokens.length === 0) {
+      await finishDelivery(delivery.id, "skipped", {
+        lastError: "No enabled push token is registered for the donor",
+      });
+      return "skipped";
+    }
+
+    const { config } = await getAdminConfigUncached();
+    const amount = Number(claim.amount);
+    const title = renderDonorSpendTemplate(config.donorSpendNotificationTitle, { amount });
+    const body = renderDonorSpendTemplate(config.donorSpendNotificationBody, { amount });
+    const tokenValues = tokens.map(({ token }) => token);
+    const summary = await postExpoPushNotifications(
+      tokenValues,
+      title,
+      body,
+      claimCodeId
+    );
+
+    await disablePushTokens(summary.unregisteredTokens);
+
+    if (summary.successfulTickets.length === 0) {
+      const failure = summary.errors.join("; ") || "Expo Push API returned no successful tickets";
+      await finishDelivery(delivery.id, "failed", {
+        title,
+        body,
+        lastError: failure,
+      });
+      console.warn("Failed to submit donor spend notification", { claimCodeId, failure });
+      return "failed";
+    }
+
+    const submittedAt = new Date();
+    await db
+      .update(schema.notificationDeliveries)
+      .set({
+        status: "submitted",
+        title,
+        body,
+        expoTicketIds: serializeExpoPushTickets(summary.successfulTickets),
+        lastError: summary.errors.length > 0 ? summary.errors.join("; ") : null,
+        submittedAt,
+        updatedAt: submittedAt,
+      })
+      .where(eq(schema.notificationDeliveries.id, delivery.id));
+    return "submitted";
+  } catch (error) {
+    const failure = errorMessage(error);
+    await finishDelivery(delivery.id, "failed", { lastError: failure }).catch((updateError) => {
+      console.error("Failed to record donor notification failure", updateError);
+    });
+    console.warn("Failed to submit donor spend notification", { claimCodeId, failure });
+    return "failed";
+  }
+}
+
+export async function processDonorSpendReceipt(
+  claimCodeId: string
+): Promise<DonorSpendReceiptResult> {
+  const now = new Date();
+  const staleProcessingBefore = new Date(now.getTime() - STALE_PROCESSING_MS);
+  const [delivery] = await db
+    .update(schema.notificationDeliveries)
+    .set({ status: "sending", updatedAt: now })
+    .where(
+      and(
+        eq(schema.notificationDeliveries.claimCodeId, claimCodeId),
+        isNotNull(schema.notificationDeliveries.expoTicketIds),
+        or(
+          eq(schema.notificationDeliveries.status, "submitted"),
+          and(
+            eq(schema.notificationDeliveries.status, "sending"),
+            lt(schema.notificationDeliveries.updatedAt, staleProcessingBefore)
+          )
+        )
+      )
+    )
+    .returning();
+
+  if (!delivery) {
+    const existing = await db
+      .select({ id: schema.notificationDeliveries.id })
+      .from(schema.notificationDeliveries)
+      .where(eq(schema.notificationDeliveries.claimCodeId, claimCodeId))
+      .limit(1);
+    return existing[0] ? "already_processing" : "not_found";
+  }
+
+  const tickets = parseExpoPushTickets(delivery.expoTicketIds);
+  if (!tickets) {
+    await finishDelivery(delivery.id, "failed", {
+      lastError: "Stored Expo ticket mapping is invalid",
+    });
+    return "failed";
+  }
+
+  try {
+    const summary = await postExpoPushReceipts(tickets);
+    await disablePushTokens(summary.unregisteredTokens);
+
+    if (!summary.isValid) {
+      await returnToSubmitted(delivery.id, summary.errors.join("; "));
+      return "waiting";
+    }
+
+    if (summary.pendingTicketIds.length > 0) {
+      const submittedAt = delivery.submittedAt ?? delivery.createdAt;
+      const hasExpiredReceipts = now.getTime() - submittedAt.getTime() >= RECEIPT_MAX_WAIT_MS;
+      if (hasExpiredReceipts) {
+        await finishDelivery(delivery.id, "failed", {
+          lastError: `Expo receipts were unavailable for ${summary.pendingTicketIds.length} ticket(s)`,
+        });
+        return "failed";
+      }
+
+      const pendingMessage = `Waiting for ${summary.pendingTicketIds.length} Expo receipt(s)`;
+      await returnToSubmitted(
+        delivery.id,
+        [...summary.errors, pendingMessage].join("; ")
+      );
+      return "waiting";
+    }
+
+    if (summary.successfulTicketIds.length === 0) {
+      const failure = summary.errors.join("; ") || "Expo rejected every push receipt";
+      await finishDelivery(delivery.id, "failed", { lastError: failure });
+      return "failed";
+    }
+
+    await finishDelivery(delivery.id, "sent", {
+      lastError: summary.errors.length > 0 ? summary.errors.join("; ") : null,
+      sentAt: new Date(),
+    });
+    return "sent";
+  } catch (error) {
+    const failure = errorMessage(error);
+    await returnToSubmitted(delivery.id, failure).catch((updateError) => {
+      console.error("Failed to record donor notification receipt error", updateError);
+    });
+    console.warn("Failed to check donor notification receipt", { claimCodeId, failure });
+    return "waiting";
+  }
+}
+
+export async function runDonorSpendDeliveryPipeline(
+  claimCodeId: string
+): Promise<DonorSpendDeliveryResult | DonorSpendReceiptResult> {
+  const deliveryResult = await deliverDonorSpendNotification(claimCodeId);
+  if (deliveryResult !== "submitted") return deliveryResult;
+
+  for (const delayMs of PIPELINE_RECEIPT_DELAYS_MS) {
+    await sleep(delayMs);
+    const receiptResult = await processDonorSpendReceipt(claimCodeId);
+    if (receiptResult === "sent" || receiptResult === "failed" || receiptResult === "not_found") {
+      return receiptResult;
+    }
+  }
+
+  return "waiting";
+}
+
+function retryDelayMs(attemptCount: number): number {
+  return Math.min(60_000 * 2 ** Math.max(0, attemptCount - 1), 6 * 60 * 60 * 1000);
+}
+
+function isQueueCandidateDue(delivery: NotificationDelivery, now: Date): boolean {
+  const ageMs = now.getTime() - delivery.updatedAt.getTime();
+  if (delivery.status === "pending") return true;
+  if (delivery.status === "failed") {
+    return (
+      delivery.attemptCount < DELIVERY_MAX_ATTEMPTS &&
+      ageMs >= retryDelayMs(delivery.attemptCount)
+    );
+  }
+  if (delivery.status === "submitted") return ageMs >= RECEIPT_RECHECK_MS;
+  if (delivery.status === "sending") return ageMs >= STALE_PROCESSING_MS;
+  return false;
+}
+
+export async function processDonorSpendNotificationQueue(
+  limit = 10
+): Promise<NotificationQueueResult> {
+  const now = new Date();
+  const candidates = await db
+    .select()
+    .from(schema.notificationDeliveries)
+    .where(
+      inArray(schema.notificationDeliveries.status, [
+        "pending",
+        "failed",
+        "submitted",
+        "sending",
+      ])
+    )
+    .orderBy(asc(schema.notificationDeliveries.updatedAt))
+    .limit(limit * QUEUE_SCAN_MULTIPLIER);
+  const due = candidates.filter((delivery) => isQueueCandidateDue(delivery, now)).slice(0, limit);
+
+  const outcomes = await Promise.all(
+    due.map(async (delivery) => {
+      if (
+        delivery.status === "submitted" ||
+        (delivery.status === "sending" && delivery.expoTicketIds)
+      ) {
+        return processDonorSpendReceipt(delivery.claimCodeId);
+      }
+      return runDonorSpendDeliveryPipeline(delivery.claimCodeId);
+    })
+  );
+  const results: Record<string, number> = {};
+  for (const outcome of outcomes) {
+    results[outcome] = (results[outcome] ?? 0) + 1;
+  }
+
+  return { processed: outcomes.length, results };
+}

--- a/apps/dashboard/lib/server/notifications/template.test.ts
+++ b/apps/dashboard/lib/server/notifications/template.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildExpoPushMessages,
+  formatNotificationAmount,
+  parseExpoPushTickets,
+  renderDonorSpendTemplate,
+  serializeExpoPushTickets,
+  summarizeExpoPushReceipts,
+  summarizeExpoPushTickets,
+} from "./template";
+
+test("Expo messages preserve configured title and body exactly", () => {
+  assert.deepEqual(
+    buildExpoPushMessages(
+      ["ExponentPushToken[first]"],
+      "A donor title",
+      "Exact body punctuation — unchanged!",
+      "claim-123"
+    ),
+    [
+      {
+        to: "ExponentPushToken[first]",
+        title: "A donor title",
+        body: "Exact body punctuation — unchanged!",
+        sound: "default",
+        channelId: "donor-updates",
+        data: { kind: "donor_spend", claimCodeId: "claim-123" },
+      },
+    ]
+  );
+});
+
+test("donor spend templates preserve exact configured copy and replace every amount token", () => {
+  assert.equal(
+    renderDonorSpendTemplate("You shared {{amount}} points. Exactly {{ amount }}!", {
+      amount: 12.5,
+    }),
+    "You shared 12.5 points. Exactly 12.5!"
+  );
+  assert.equal(renderDonorSpendTemplate("Thank you, Banana Slug!", { amount: 10 }), "Thank you, Banana Slug!");
+});
+
+test("notification amounts are stable and limited to two decimal places", () => {
+  assert.equal(formatNotificationAmount(10), "10");
+  assert.equal(formatNotificationAmount(10.5), "10.5");
+  assert.equal(formatNotificationAmount(10.126), "10.13");
+});
+
+test("Expo ticket summaries retain successes and identify dead device tokens", () => {
+  assert.deepEqual(
+    summarizeExpoPushTickets(
+      {
+        data: [
+          { status: "ok", id: "ticket-1" },
+          {
+            status: "error",
+            message: "The device is no longer registered",
+            details: { error: "DeviceNotRegistered" },
+          },
+        ],
+      },
+      ["ExponentPushToken[first]", "ExponentPushToken[second]"]
+    ),
+    {
+      errors: ["The device is no longer registered"],
+      successfulTickets: [
+        { id: "ticket-1", token: "ExponentPushToken[first]" },
+      ],
+      unregisteredTokens: ["ExponentPushToken[second]"],
+    }
+  );
+});
+
+test("invalid Expo responses fail closed", () => {
+  assert.deepEqual(summarizeExpoPushTickets({}, ["ExponentPushToken[first]"]), {
+    errors: ["Expo Push API returned an invalid response"],
+    successfulTickets: [],
+    unregisteredTokens: [],
+  });
+});
+
+test("ticket mappings round-trip for later receipt checks", () => {
+  const tickets = [
+    { id: "ticket-1", token: "ExponentPushToken[first]" },
+    { id: "ticket-2", token: "ExponentPushToken[second]" },
+  ];
+  assert.deepEqual(parseExpoPushTickets(serializeExpoPushTickets(tickets)), tickets);
+  assert.equal(parseExpoPushTickets('[{"id":"ticket-1"}]'), null);
+  assert.equal(parseExpoPushTickets("not-json"), null);
+});
+
+test("receipt summaries retain pending tickets and identify dead devices", () => {
+  assert.deepEqual(
+    summarizeExpoPushReceipts(
+      {
+        data: {
+          "ticket-1": { status: "ok" },
+          "ticket-2": {
+            status: "error",
+            message: "The device is no longer registered",
+            details: { error: "DeviceNotRegistered" },
+          },
+        },
+      },
+      [
+        { id: "ticket-1", token: "ExponentPushToken[first]" },
+        { id: "ticket-2", token: "ExponentPushToken[second]" },
+        { id: "ticket-3", token: "ExponentPushToken[third]" },
+      ]
+    ),
+    {
+      errors: ["The device is no longer registered"],
+      isValid: true,
+      pendingTicketIds: ["ticket-3"],
+      successfulTicketIds: ["ticket-1"],
+      unregisteredTokens: ["ExponentPushToken[second]"],
+    }
+  );
+});
+
+test("invalid receipt responses fail closed", () => {
+  assert.deepEqual(
+    summarizeExpoPushReceipts({}, [
+      { id: "ticket-1", token: "ExponentPushToken[first]" },
+    ]),
+    {
+      errors: ["Expo Push Receipt API returned an invalid response"],
+      isValid: false,
+      pendingTicketIds: [],
+      successfulTicketIds: [],
+      unregisteredTokens: [],
+    }
+  );
+});

--- a/apps/dashboard/lib/server/notifications/template.ts
+++ b/apps/dashboard/lib/server/notifications/template.ts
@@ -1,0 +1,206 @@
+export type DonorSpendTemplateVariables = {
+  amount: number;
+};
+
+export function formatNotificationAmount(amount: number): string {
+  if (!Number.isFinite(amount)) return "0";
+  return amount.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+    useGrouping: false,
+  });
+}
+
+export function renderDonorSpendTemplate(
+  template: string,
+  variables: DonorSpendTemplateVariables
+): string {
+  return template.replace(
+    /{{\s*amount\s*}}/g,
+    formatNotificationAmount(variables.amount)
+  );
+}
+
+export type ExpoPushTicketSummary = {
+  errors: string[];
+  successfulTickets: ExpoPushTicket[];
+  unregisteredTokens: string[];
+};
+
+export type ExpoPushTicket = {
+  id: string;
+  token: string;
+};
+
+export type ExpoPushReceiptSummary = {
+  errors: string[];
+  isValid: boolean;
+  pendingTicketIds: string[];
+  successfulTicketIds: string[];
+  unregisteredTokens: string[];
+};
+
+export function buildExpoPushMessages(
+  tokens: string[],
+  title: string,
+  body: string,
+  claimCodeId: string
+) {
+  return tokens.map((to) => ({
+    to,
+    title,
+    body,
+    sound: "default" as const,
+    channelId: "donor-updates",
+    data: {
+      kind: "donor_spend",
+      claimCodeId,
+    },
+  }));
+}
+
+export function summarizeExpoPushTickets(
+  payload: unknown,
+  tokens: string[]
+): ExpoPushTicketSummary {
+  const data =
+    payload && typeof payload === "object" && Array.isArray((payload as { data?: unknown }).data)
+      ? (payload as { data: unknown[] }).data
+      : null;
+
+  if (!data) {
+    return {
+      errors: ["Expo Push API returned an invalid response"],
+      successfulTickets: [],
+      unregisteredTokens: [],
+    };
+  }
+
+  const errors: string[] = [];
+  const successfulTickets: ExpoPushTicket[] = [];
+  const unregisteredTokens: string[] = [];
+
+  data.forEach((rawTicket, index) => {
+    const ticket = rawTicket as {
+      status?: unknown;
+      id?: unknown;
+      message?: unknown;
+      details?: { error?: unknown };
+    };
+    const token = tokens[index];
+    if (ticket?.status === "ok" && typeof ticket.id === "string" && token) {
+      successfulTickets.push({ id: ticket.id, token });
+      return;
+    }
+
+    const detail = ticket?.details?.error;
+    if (detail === "DeviceNotRegistered" && token) {
+      unregisteredTokens.push(token);
+    }
+    errors.push(
+      typeof ticket?.message === "string"
+        ? ticket.message
+        : typeof detail === "string"
+          ? detail
+          : "Expo Push API rejected a notification"
+    );
+  });
+
+  if (data.length < tokens.length) {
+    errors.push("Expo Push API omitted one or more notification tickets");
+  }
+
+  return { errors, successfulTickets, unregisteredTokens };
+}
+
+export function serializeExpoPushTickets(tickets: ExpoPushTicket[]): string {
+  return JSON.stringify(tickets);
+}
+
+export function parseExpoPushTickets(value: string | null): ExpoPushTicket[] | null {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed) || parsed.length === 0) return null;
+
+    const tickets = parsed.flatMap((entry) => {
+      if (!entry || typeof entry !== "object") return [];
+      const candidate = entry as { id?: unknown; token?: unknown };
+      return typeof candidate.id === "string" && typeof candidate.token === "string"
+        ? [{ id: candidate.id, token: candidate.token }]
+        : [];
+    });
+
+    return tickets.length === parsed.length ? tickets : null;
+  } catch {
+    return null;
+  }
+}
+
+export function summarizeExpoPushReceipts(
+  payload: unknown,
+  tickets: ExpoPushTicket[]
+): ExpoPushReceiptSummary {
+  const data =
+    payload &&
+    typeof payload === "object" &&
+    (payload as { data?: unknown }).data &&
+    typeof (payload as { data: unknown }).data === "object" &&
+    !Array.isArray((payload as { data: unknown }).data)
+      ? ((payload as { data: Record<string, unknown> }).data)
+      : null;
+
+  if (!data) {
+    return {
+      errors: ["Expo Push Receipt API returned an invalid response"],
+      isValid: false,
+      pendingTicketIds: [],
+      successfulTicketIds: [],
+      unregisteredTokens: [],
+    };
+  }
+
+  const errors: string[] = [];
+  const pendingTicketIds: string[] = [];
+  const successfulTicketIds: string[] = [];
+  const unregisteredTokens: string[] = [];
+
+  for (const ticket of tickets) {
+    const rawReceipt = data[ticket.id];
+    if (rawReceipt === undefined) {
+      pendingTicketIds.push(ticket.id);
+      continue;
+    }
+
+    const receipt = rawReceipt as {
+      status?: unknown;
+      message?: unknown;
+      details?: { error?: unknown };
+    };
+    if (receipt?.status === "ok") {
+      successfulTicketIds.push(ticket.id);
+      continue;
+    }
+
+    const detail = receipt?.details?.error;
+    if (detail === "DeviceNotRegistered") {
+      unregisteredTokens.push(ticket.token);
+    }
+    errors.push(
+      typeof receipt?.message === "string"
+        ? receipt.message
+        : typeof detail === "string"
+          ? detail
+          : "Expo could not deliver a notification to the push provider"
+    );
+  }
+
+  return {
+    errors,
+    isValid: true,
+    pendingTicketIds,
+    successfulTicketIds,
+    unregisteredTokens,
+  };
+}

--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -2,5 +2,11 @@
   "framework": "nextjs",
   "installCommand": "cd ../.. && npm install",
   "buildCommand": "npm run build",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "crons": [
+    {
+      "path": "/api/cron/notifications",
+      "schedule": "17 9 * * *"
+    }
+  ]
 }

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "SlugSwap",
     "slug": "slugswap",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -17,7 +17,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.anonymous.slugswap",
-      "buildNumber": "44",
+      "buildNumber": "45",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }
@@ -40,6 +40,7 @@
     "plugins": [
       "expo-router",
       "expo-web-browser",
+      "expo-notifications",
       [
         "expo-maps",
         {

--- a/apps/mobile/app/(tabs)/(share)/index.tsx
+++ b/apps/mobile/app/(tabs)/(share)/index.tsx
@@ -7,6 +7,7 @@ import {
   RefreshControl,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   TextInput,
   View,
@@ -26,6 +27,7 @@ import {
   getMobileHome,
   linkGetAccount,
   pauseDonation,
+  updateDonorSpendNotificationPreference,
   setDonation,
   unlinkGetAccount,
   type DonorImpact,
@@ -36,6 +38,12 @@ import {
   type GetAccountBalance,
   type ShareTabSnapshot,
 } from '@/lib/tab-cache-context';
+import {
+  enablePushNotificationsAsync,
+  scheduleNotificationPreviewAsync,
+  syncExistingPushRegistrationAsync,
+  unregisterStoredPushTokenAsync,
+} from '@/lib/notifications';
 import {
   buttonOpacity,
   cardShadow,
@@ -50,6 +58,7 @@ const POOL_EMPTY_MESSAGE = 'The shared donor pool is empty right now. Check back
 
 const EMPTY_IMPACT: DonorImpact = {
   isActive: false,
+  notifyOnSpend: false,
   weeklyAmount: 0,
   status: 'paused',
   peopleHelped: 0,
@@ -73,6 +82,7 @@ function normalizeDonorImpact(raw: Partial<DonorImpact> | null | undefined): Don
   if (!raw) return EMPTY_IMPACT;
   return {
     isActive: !!raw.isActive,
+    notifyOnSpend: raw.notifyOnSpend === true,
     weeklyAmount: toSafeNumber(raw.weeklyAmount),
     status: typeof raw.status === 'string' ? raw.status : EMPTY_IMPACT.status,
     peopleHelped: toSafeNumber(raw.peopleHelped),
@@ -246,6 +256,8 @@ export default function DonorScreen() {
   const [getAccounts, setGetAccounts] = useState<GetAccountBalance[]>(shareSnapshot?.getAccounts ?? []);
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(false);
+  const [notificationsSyncing, setNotificationsSyncing] = useState(false);
   const [requesterWeeklyLimit, setRequesterWeeklyLimit] = useState(shareSnapshot?.requesterWeeklyLimit ?? 0);
   const [requesterWeekEnd, setRequesterWeekEnd] = useState<string | null>(shareSnapshot?.requesterWeekEnd ?? null);
   const [requesterDaysUntilReset, setRequesterDaysUntilReset] = useState(shareSnapshot?.requesterDaysUntilReset ?? 0);
@@ -256,6 +268,7 @@ export default function DonorScreen() {
   const getAccountsRequestIdRef = useRef(0);
   const homeRequestIdRef = useRef(0);
   const skipInitialFocusRefreshRef = useRef(!hasShareSnapshot);
+  const notificationRegistrationCheckedForUserRef = useRef<string | null>(null);
 
   useEffect(() => {
     shareSnapshotRef.current = shareSnapshot;
@@ -449,6 +462,104 @@ export default function DonorScreen() {
     }, [loadUserAndImpact])
   );
 
+  useEffect(() => {
+    if (!userId) {
+      notificationRegistrationCheckedForUserRef.current = null;
+      setNotificationsEnabled(false);
+      return;
+    }
+    if (!impact.notifyOnSpend) {
+      notificationRegistrationCheckedForUserRef.current = null;
+      setNotificationsEnabled(false);
+      return;
+    }
+    if (notificationRegistrationCheckedForUserRef.current === userId) return;
+    notificationRegistrationCheckedForUserRef.current = userId;
+
+    let active = true;
+    void syncExistingPushRegistrationAsync()
+      .then((registered) => {
+        if (active) setNotificationsEnabled(registered);
+      })
+      .catch((error) => {
+        console.warn('Failed to refresh notification registration:', error);
+        if (active) setNotificationsEnabled(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [impact.notifyOnSpend, userId]);
+
+  const setLocalNotificationPreference = useCallback(
+    (enabled: boolean) => {
+      setImpact((currentImpact) => {
+        const nextImpact = { ...currentImpact, notifyOnSpend: enabled };
+        const currentSnapshot = shareSnapshotRef.current;
+        if (currentSnapshot) {
+          updateShareSnapshot({ ...currentSnapshot, impact: nextImpact });
+        }
+        return nextImpact;
+      });
+    },
+    [updateShareSnapshot]
+  );
+
+  const enableSpendNotifications = useCallback(async () => {
+    setNotificationsSyncing(true);
+    try {
+      const result = await enablePushNotificationsAsync();
+      if (result.status === 'registered') {
+        await updateDonorSpendNotificationPreference(true);
+        setNotificationsEnabled(true);
+        setLocalNotificationPreference(true);
+        return true;
+      }
+
+      setNotificationsEnabled(false);
+      if (result.status === 'denied') {
+        Alert.alert(
+          'Notifications are off',
+          'Allow notifications for SlugSwap in Settings, then try again.'
+        );
+      } else if (result.status === 'unsupported') {
+        Alert.alert('Unavailable', 'Push notifications are only available in the native app.');
+      } else {
+        Alert.alert('Could not enable notifications', result.message);
+      }
+      return false;
+    } catch (error) {
+      console.error('Failed to enable spend notifications:', error);
+      setNotificationsEnabled(false);
+      Alert.alert('Could not enable notifications', 'Please try again in a moment.');
+      return false;
+    } finally {
+      setNotificationsSyncing(false);
+    }
+  }, [setLocalNotificationPreference]);
+
+  const handleNotificationToggle = useCallback(
+    async (enabled: boolean) => {
+      if (enabled) {
+        await enableSpendNotifications();
+        return;
+      }
+
+      setNotificationsSyncing(true);
+      try {
+        await updateDonorSpendNotificationPreference(false);
+        setNotificationsEnabled(false);
+        setLocalNotificationPreference(false);
+      } catch (error) {
+        console.error('Failed to disable spend notifications:', error);
+        Alert.alert('Could not update notifications', 'Please try again in a moment.');
+      } finally {
+        setNotificationsSyncing(false);
+      }
+    },
+    [enableSpendNotifications, setLocalNotificationPreference]
+  );
+
   const handleSetContribution = async () => {
     if (!userId) return;
 
@@ -464,8 +575,32 @@ export default function DonorScreen() {
       await setDonation(amount);
       invalidateHomeRequests();
       setIsActive(true);
-      Alert.alert('Success', 'Your contribution has been set!');
       await loadUserAndImpact({ showBlockingLoader: false });
+      if (Platform.OS === 'web') {
+        Alert.alert('Success', 'Your contribution has been set!');
+      } else {
+        Alert.alert(
+          'Sharing started',
+          'Would you like a notification whenever someone spends your donated SlugPoints?',
+          [
+            {
+              text: 'Not now',
+              style: 'cancel',
+              onPress: () => {
+                void updateDonorSpendNotificationPreference(false)
+                  .then(() => setLocalNotificationPreference(false))
+                  .catch((error) => console.warn('Failed to disable notification preference:', error));
+              },
+            },
+            {
+              text: 'Enable',
+              onPress: () => {
+                void enableSpendNotifications();
+              },
+            },
+          ]
+        );
+      }
     } catch (error) {
       console.error('Error setting donation:', error);
       Alert.alert('Error', 'Failed to set contribution. Please try again.');
@@ -599,7 +734,23 @@ export default function DonorScreen() {
     getAccountsRequestIdRef.current += 1;
     setIsSigningOut(true);
     try {
-      await signOut();
+      try {
+        await unregisterStoredPushTokenAsync();
+      } catch (error) {
+        console.warn('Failed to disconnect push notifications during sign out:', error);
+        Alert.alert(
+          'Could not sign out',
+          'SlugSwap could not disconnect notifications from this device. Check your connection and try again.'
+        );
+        return;
+      }
+
+      try {
+        await signOut();
+      } catch (error) {
+        console.warn('Failed to sign out:', error);
+        Alert.alert('Could not sign out', 'Check your connection and try again.');
+      }
     } finally {
       setIsSigningOut(false);
     }
@@ -845,6 +996,28 @@ export default function DonorScreen() {
                   <Text style={styles.capFootnote}>Tracking week in {impact.timezone}</Text>
                 </View>
 
+                <View style={styles.notificationRow}>
+                  <View style={styles.notificationCopy}>
+                    <Text style={styles.notificationTitle}>Spend notifications</Text>
+                    <Text style={styles.notificationDetail}>
+                      {notificationsEnabled
+                        ? 'You will know when your donated points help someone.'
+                        : 'Enable alerts when someone spends your donated points.'}
+                    </Text>
+                  </View>
+                  {notificationsSyncing ? (
+                    <ActivityIndicator size="small" color={colors.brand} />
+                  ) : (
+                    <Switch
+                      value={notificationsEnabled}
+                      onValueChange={(enabled) => {
+                        void handleNotificationToggle(enabled);
+                      }}
+                      trackColor={{ false: colors.borderStrong, true: colors.brand }}
+                    />
+                  )}
+                </View>
+
                 <View style={styles.buttonRow}>
                   <SecondaryButton
                     label={isActive ? 'Pause Sharing' : 'Resume Sharing'}
@@ -857,6 +1030,33 @@ export default function DonorScreen() {
                 </View>
               </>
             )}
+          </SectionCard>
+        ) : null}
+
+        {__DEV__ && Platform.OS !== 'web' ? (
+          <SectionCard>
+            <SectionHeader
+              icon="bell.fill"
+              title="Notification Test"
+              detail="Development builds only"
+            />
+            <View style={styles.buttonRow}>
+              <SecondaryButton
+                label="Send Test Notification"
+                icon="bell.fill"
+                onPress={() => {
+                  void scheduleNotificationPreviewAsync(
+                    'Your SlugPoints helped someone',
+                    'Someone just spent 10 of your donated SlugPoints. Thank you for sharing!'
+                  ).catch((error) => {
+                    Alert.alert(
+                      'Test notification failed',
+                      error instanceof Error ? error.message : 'Please try again.'
+                    );
+                  });
+                }}
+              />
+            </View>
           </SectionCard>
         ) : null}
 
@@ -1189,6 +1389,33 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.border,
     gap: 10,
+  },
+  notificationRow: {
+    marginHorizontal: 18,
+    marginTop: 16,
+    minHeight: 72,
+    padding: 14,
+    borderRadius: 18,
+    backgroundColor: colors.surfaceMuted,
+    borderWidth: 1,
+    borderColor: colors.border,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+  },
+  notificationCopy: {
+    flex: 1,
+    gap: 3,
+  },
+  notificationTitle: {
+    color: colors.text,
+    fontSize: 15,
+    lineHeight: 20,
+    fontWeight: '700',
+  },
+  notificationDetail: {
+    ...typeScale.caption,
+    color: colors.textMuted,
   },
   capRow: {
     flexDirection: 'row',

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-native';
 import Constants from 'expo-constants';
 import { getMobileAppConfig } from '@/lib/api';
+import { configureNotificationHandlingAsync } from '@/lib/notifications';
 import { cardShadow, stealthTheme } from '../lib/stealth-theme';
 
 type RequiredUpdateGate = {
@@ -194,6 +195,12 @@ export default function RootLayout() {
       updateCheckInFlightRef.current = false;
     }
   }, [checkRequiredNativeUpdate, checkOtaUpdate]);
+
+  useEffect(() => {
+    void configureNotificationHandlingAsync().catch((error) => {
+      console.warn('Failed to configure notification handling:', error);
+    });
+  }, []);
 
   useEffect(() => {
     void runUpdateChecks();

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -187,6 +187,7 @@ if (__DEV__) {
 
 export type DonorImpact = {
   isActive: boolean;
+  notifyOnSpend: boolean;
   weeklyAmount: number;
   status: string;
   peopleHelped: number;
@@ -401,6 +402,52 @@ export async function pauseDonation(paused: boolean) {
   }
 
   return readApiJson(response, 'Failed to read donation status response');
+}
+
+export async function registerPushToken(token: string, platform: 'ios' | 'android') {
+  const headers = await getAuthHeaders();
+  const response = await fetchWithFallback(`${API_BASE_URL}/api/notifications/register`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ token, platform }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response, 'Failed to register this device'));
+  }
+
+  return readApiJson<{ success: boolean }>(response, 'Failed to read device registration');
+}
+
+export async function unregisterPushToken(token: string) {
+  const headers = await getAuthHeaders();
+  const response = await fetchWithFallback(`${API_BASE_URL}/api/notifications/unregister`, {
+    method: 'DELETE',
+    headers,
+    body: JSON.stringify({ token }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response, 'Failed to unregister this device'));
+  }
+}
+
+export async function updateDonorSpendNotificationPreference(enabled: boolean) {
+  const headers = await getAuthHeaders();
+  const response = await fetchWithFallback(`${API_BASE_URL}/api/notifications/preference`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({ enabled }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response, 'Failed to update notification preference'));
+  }
+
+  return readApiJson<{ success: boolean; notifyOnSpend: boolean }>(
+    response,
+    'Failed to read notification preference'
+  );
 }
 
 export async function generateClaimCode(amount?: number) {

--- a/apps/mobile/lib/notifications.ts
+++ b/apps/mobile/lib/notifications.ts
@@ -1,0 +1,151 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
+
+import { registerPushToken, unregisterPushToken } from './api';
+
+const STORED_PUSH_TOKEN_KEY = 'slugswap:expo-push-token:v1';
+let handlerConfigured = false;
+
+type RegistrationResult =
+  | { status: 'registered'; token: string }
+  | { status: 'denied' }
+  | { status: 'unsupported' }
+  | { status: 'failed'; message: string };
+
+function getProjectId(): string | null {
+  return (
+    Constants.expoConfig?.extra?.eas?.projectId ??
+    Constants.easConfig?.projectId ??
+    null
+  );
+}
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unable to configure notifications';
+}
+
+function notificationsAreAllowed(
+  permissions: Awaited<ReturnType<typeof import('expo-notifications').getPermissionsAsync>>,
+  Notifications: typeof import('expo-notifications')
+): boolean {
+  const iosStatus = permissions.ios?.status;
+  return (
+    permissions.granted ||
+    iosStatus === Notifications.IosAuthorizationStatus.AUTHORIZED ||
+    iosStatus === Notifications.IosAuthorizationStatus.PROVISIONAL ||
+    iosStatus === Notifications.IosAuthorizationStatus.EPHEMERAL
+  );
+}
+
+export async function configureNotificationHandlingAsync(): Promise<void> {
+  if (Platform.OS === 'web' || handlerConfigured) return;
+
+  const Notifications = await import('expo-notifications');
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowBanner: true,
+      shouldShowList: true,
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+    }),
+  });
+
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('donor-updates', {
+      name: 'Donor updates',
+      description: 'Updates when donated SlugPoints help another student',
+      importance: Notifications.AndroidImportance.HIGH,
+      sound: 'default',
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: '#1E84C4',
+    });
+  }
+
+  handlerConfigured = true;
+}
+
+async function getPushTokenAsync(requestPermission: boolean): Promise<RegistrationResult> {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+    return { status: 'unsupported' };
+  }
+
+  try {
+    await configureNotificationHandlingAsync();
+    const Notifications = await import('expo-notifications');
+    let permissions = await Notifications.getPermissionsAsync();
+
+    if (!notificationsAreAllowed(permissions, Notifications) && requestPermission) {
+      permissions = await Notifications.requestPermissionsAsync({
+        ios: {
+          allowAlert: true,
+          allowBadge: true,
+          allowSound: true,
+        },
+      });
+    }
+
+    if (!notificationsAreAllowed(permissions, Notifications)) {
+      return { status: 'denied' };
+    }
+
+    const projectId = getProjectId();
+    if (!projectId) {
+      return { status: 'failed', message: 'EAS project ID is missing' };
+    }
+
+    const token = (await Notifications.getExpoPushTokenAsync({ projectId })).data;
+    await registerPushToken(token, Platform.OS);
+    await AsyncStorage.setItem(STORED_PUSH_TOKEN_KEY, token);
+    return { status: 'registered', token };
+  } catch (error) {
+    return { status: 'failed', message: messageFromError(error) };
+  }
+}
+
+export function enablePushNotificationsAsync(): Promise<RegistrationResult> {
+  return getPushTokenAsync(true);
+}
+
+export async function syncExistingPushRegistrationAsync(): Promise<boolean> {
+  const storedToken = await AsyncStorage.getItem(STORED_PUSH_TOKEN_KEY);
+  if (!storedToken) return false;
+
+  const result = await getPushTokenAsync(false);
+  return result.status === 'registered';
+}
+
+export async function unregisterStoredPushTokenAsync(): Promise<void> {
+  const token = await AsyncStorage.getItem(STORED_PUSH_TOKEN_KEY);
+  if (!token) return;
+
+  await unregisterPushToken(token);
+  await AsyncStorage.removeItem(STORED_PUSH_TOKEN_KEY);
+}
+
+export async function scheduleNotificationPreviewAsync(
+  title: string,
+  body: string
+): Promise<void> {
+  if (Platform.OS === 'web') return;
+  await configureNotificationHandlingAsync();
+  const Notifications = await import('expo-notifications');
+  let permissions = await Notifications.getPermissionsAsync();
+  if (!notificationsAreAllowed(permissions, Notifications)) {
+    permissions = await Notifications.requestPermissionsAsync({
+      ios: { allowAlert: true, allowBadge: true, allowSound: true },
+    });
+  }
+  if (!notificationsAreAllowed(permissions, Notifications)) {
+    throw new Error('Notification permission was not granted');
+  }
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title,
+      body,
+      sound: 'default',
+      data: { kind: 'donor_spend_preview' },
+    },
+    trigger: null,
+  });
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,6 +24,7 @@
     "expo-dev-client": "~55.0.38",
     "expo-linking": "~55.0.17",
     "expo-maps": "~55.0.22",
+    "expo-notifications": "~55.0.26",
     "expo-router": "~55.0.18",
     "expo-status-bar": "~55.0.6",
     "expo-symbols": "~55.0.9",

--- a/apps/mobile/test-fixtures/donor-spend.apns
+++ b/apps/mobile/test-fixtures/donor-spend.apns
@@ -1,0 +1,12 @@
+{
+  "Simulator Target Bundle": "com.anonymous.slugswap",
+  "aps": {
+    "alert": {
+      "title": "Your SlugPoints helped someone",
+      "body": "Someone just spent 10 of your donated SlugPoints. Thank you for sharing!"
+    },
+    "sound": "default"
+  },
+  "kind": "donor_spend",
+  "claimCodeId": "simulator-test-claim"
+}

--- a/db/migrations/0006_premium_silver_samurai.sql
+++ b/db/migrations/0006_premium_silver_samurai.sql
@@ -1,0 +1,98 @@
+CREATE TABLE "notification_deliveries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"claim_code_id" uuid NOT NULL,
+	"donor_user_id" uuid NOT NULL,
+	"kind" text DEFAULT 'donor_spend' NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"title" text,
+	"body" text,
+	"attempt_count" integer DEFAULT 0 NOT NULL,
+	"expo_ticket_ids" text,
+	"last_error" text,
+	"submitted_at" timestamp,
+	"sent_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "notification_deliveries_claim_code_id_unique" UNIQUE("claim_code_id"),
+	CONSTRAINT "notification_deliveries_kind_valid" CHECK ("notification_deliveries"."kind" = 'donor_spend'),
+	CONSTRAINT "notification_deliveries_status_valid" CHECK ("notification_deliveries"."status" in ('pending', 'sending', 'submitted', 'sent', 'failed', 'skipped')),
+	CONSTRAINT "notification_deliveries_attempts_nonnegative" CHECK ("notification_deliveries"."attempt_count" >= 0)
+);
+--> statement-breakpoint
+CREATE TABLE "push_tokens" (
+	"token" text PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"platform" text NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "push_tokens_platform_valid" CHECK ("push_tokens"."platform" in ('ios', 'android'))
+);
+--> statement-breakpoint
+ALTER TABLE "admin_config" ADD COLUMN IF NOT EXISTS "donor_spend_notification_title" text DEFAULT 'Your SlugPoints helped someone' NOT NULL;--> statement-breakpoint
+ALTER TABLE "admin_config" ADD COLUMN IF NOT EXISTS "donor_spend_notification_body" text DEFAULT 'Someone just spent {{amount}} of your donated SlugPoints. Thank you for sharing!' NOT NULL;--> statement-breakpoint
+ALTER TABLE "donations" ADD COLUMN IF NOT EXISTS "notify_on_spend" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification_deliveries" ADD CONSTRAINT "notification_deliveries_claim_code_id_claim_codes_id_fk" FOREIGN KEY ("claim_code_id") REFERENCES "public"."claim_codes"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notification_deliveries" ADD CONSTRAINT "notification_deliveries_donor_user_id_users_id_fk" FOREIGN KEY ("donor_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "push_tokens" ADD CONSTRAINT "push_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_notification_deliveries_retry" ON "notification_deliveries" USING btree ("status","updated_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_push_tokens_user_enabled" ON "push_tokens" USING btree ("user_id","enabled");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "claim_codes_active_requester_unique" ON "claim_codes" USING btree ("user_id") WHERE "claim_codes"."status" = 'active';--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "claim_codes_active_donor_unique" ON "claim_codes" USING btree ("donor_user_id") WHERE "claim_codes"."status" = 'active';--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "donations_user_id_unique" ON "donations" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "user_allowances_user_weekly_pool_unique" ON "user_allowances" USING btree ("user_id","weekly_pool_id");--> statement-breakpoint
+DO $migration$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'admin_config_positive_values') THEN
+    ALTER TABLE "admin_config" ADD CONSTRAINT "admin_config_positive_values" CHECK ("admin_config"."default_weekly_allowance" > 0 and "admin_config"."default_claim_amount" > 0 and "admin_config"."code_expiry_minutes" > 0 and "admin_config"."max_claims_per_day" > 0 and "admin_config"."min_donation_amount" > 0 and "admin_config"."max_donation_amount" > 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'admin_config_donation_range_valid') THEN
+    ALTER TABLE "admin_config" ADD CONSTRAINT "admin_config_donation_range_valid" CHECK ("admin_config"."min_donation_amount" <= "admin_config"."max_donation_amount");
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'admin_config_claim_within_allowance') THEN
+    ALTER TABLE "admin_config" ADD CONSTRAINT "admin_config_claim_within_allowance" CHECK ("admin_config"."default_claim_amount" <= "admin_config"."default_weekly_allowance");
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'admin_config_pool_method_valid') THEN
+    ALTER TABLE "admin_config" ADD CONSTRAINT "admin_config_pool_method_valid" CHECK ("admin_config"."pool_calculation_method" in ('equal', 'proportional'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'admin_config_donor_policy_valid') THEN
+    ALTER TABLE "admin_config" ADD CONSTRAINT "admin_config_donor_policy_valid" CHECK ("admin_config"."donor_selection_policy" in ('round_robin', 'weighted_round_robin', 'least_utilized', 'highest_balance'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'claim_codes_amount_positive') THEN
+    ALTER TABLE "claim_codes" ADD CONSTRAINT "claim_codes_amount_positive" CHECK ("claim_codes"."amount" > 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'claim_codes_status_valid') THEN
+    ALTER TABLE "claim_codes" ADD CONSTRAINT "claim_codes_status_valid" CHECK ("claim_codes"."status" in ('pending', 'active', 'redeemed', 'expired', 'cancelled'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'claim_codes_expiry_valid') THEN
+    ALTER TABLE "claim_codes" ADD CONSTRAINT "claim_codes_expiry_valid" CHECK ("claim_codes"."expires_at" > "claim_codes"."created_at");
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'donations_amount_positive') THEN
+    ALTER TABLE "donations" ADD CONSTRAINT "donations_amount_positive" CHECK ("donations"."amount" > 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'donations_status_valid') THEN
+    ALTER TABLE "donations" ADD CONSTRAINT "donations_status_valid" CHECK ("donations"."status" in ('active', 'paused', 'cancelled'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'donations_date_window_valid') THEN
+    ALTER TABLE "donations" ADD CONSTRAINT "donations_date_window_valid" CHECK ("donations"."end_date" is null or "donations"."end_date" >= "donations"."start_date");
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'redemptions_amount_positive') THEN
+    ALTER TABLE "redemptions" ADD CONSTRAINT "redemptions_amount_positive" CHECK ("redemptions"."amount" > 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_allowances_amounts_nonnegative') THEN
+    ALTER TABLE "user_allowances" ADD CONSTRAINT "user_allowances_amounts_nonnegative" CHECK ("user_allowances"."weekly_limit" >= 0 and "user_allowances"."used_amount" >= 0 and "user_allowances"."remaining_amount" >= 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_allowances_remaining_within_limit') THEN
+    ALTER TABLE "user_allowances" ADD CONSTRAINT "user_allowances_remaining_within_limit" CHECK ("user_allowances"."remaining_amount" <= "user_allowances"."weekly_limit");
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'weekly_pools_window_valid') THEN
+    ALTER TABLE "weekly_pools" ADD CONSTRAINT "weekly_pools_window_valid" CHECK ("weekly_pools"."week_end" > "weekly_pools"."week_start");
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'weekly_pools_amounts_nonnegative') THEN
+    ALTER TABLE "weekly_pools" ADD CONSTRAINT "weekly_pools_amounts_nonnegative" CHECK ("weekly_pools"."total_amount" >= 0 and "weekly_pools"."allocated_amount" >= 0 and "weekly_pools"."remaining_amount" >= 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'weekly_pools_balances_within_total') THEN
+    ALTER TABLE "weekly_pools" ADD CONSTRAINT "weekly_pools_balances_within_total" CHECK ("weekly_pools"."allocated_amount" <= "weekly_pools"."total_amount" and "weekly_pools"."remaining_amount" <= "weekly_pools"."total_amount");
+  END IF;
+END
+$migration$;

--- a/db/migrations/meta/0006_snapshot.json
+++ b/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1213 @@
+{
+  "id": "521cf789-068a-4355-9f93-b4ecf1701c5b",
+  "prevId": "51f8b0a2-5ee8-438a-abe9-4cbe952b2f16",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_config": {
+      "name": "admin_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "default_weekly_allowance": {
+          "name": "default_weekly_allowance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "default_claim_amount": {
+          "name": "default_claim_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "code_expiry_minutes": {
+          "name": "code_expiry_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "pool_calculation_method": {
+          "name": "pool_calculation_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'equal'"
+        },
+        "max_claims_per_day": {
+          "name": "max_claims_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "min_donation_amount": {
+          "name": "min_donation_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "max_donation_amount": {
+          "name": "max_donation_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "donor_selection_policy": {
+          "name": "donor_selection_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'least_utilized'"
+        },
+        "ios_required_version": {
+          "name": "ios_required_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "android_required_version": {
+          "name": "android_required_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "ios_store_url": {
+          "name": "ios_store_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "android_store_url": {
+          "name": "android_store_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "donor_spend_notification_title": {
+          "name": "donor_spend_notification_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Your SlugPoints helped someone'"
+        },
+        "donor_spend_notification_body": {
+          "name": "donor_spend_notification_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone just spent {{amount}} of your donated SlugPoints. Thank you for sharing!'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_config_positive_values": {
+          "name": "admin_config_positive_values",
+          "value": "\"admin_config\".\"default_weekly_allowance\" > 0 and \"admin_config\".\"default_claim_amount\" > 0 and \"admin_config\".\"code_expiry_minutes\" > 0 and \"admin_config\".\"max_claims_per_day\" > 0 and \"admin_config\".\"min_donation_amount\" > 0 and \"admin_config\".\"max_donation_amount\" > 0"
+        },
+        "admin_config_donation_range_valid": {
+          "name": "admin_config_donation_range_valid",
+          "value": "\"admin_config\".\"min_donation_amount\" <= \"admin_config\".\"max_donation_amount\""
+        },
+        "admin_config_claim_within_allowance": {
+          "name": "admin_config_claim_within_allowance",
+          "value": "\"admin_config\".\"default_claim_amount\" <= \"admin_config\".\"default_weekly_allowance\""
+        },
+        "admin_config_pool_method_valid": {
+          "name": "admin_config_pool_method_valid",
+          "value": "\"admin_config\".\"pool_calculation_method\" in ('equal', 'proportional')"
+        },
+        "admin_config_donor_policy_valid": {
+          "name": "admin_config_donor_policy_valid",
+          "value": "\"admin_config\".\"donor_selection_policy\" in ('round_robin', 'weighted_round_robin', 'least_utilized', 'highest_balance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.claim_codes": {
+      "name": "claim_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_pool_id": {
+          "name": "weekly_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donor_user_id": {
+          "name": "donor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_snapshot": {
+          "name": "balance_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_claim_codes_donor_redeemed": {
+          "name": "idx_claim_codes_donor_redeemed",
+          "columns": [
+            {
+              "expression": "donor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "redeemed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claim_codes\".\"status\" = 'redeemed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_claim_codes_donor_active_reservation": {
+          "name": "idx_claim_codes_donor_active_reservation",
+          "columns": [
+            {
+              "expression": "donor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claim_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claim_codes_active_requester_unique": {
+          "name": "claim_codes_active_requester_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"claim_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claim_codes_active_donor_unique": {
+          "name": "claim_codes_active_donor_unique",
+          "columns": [
+            {
+              "expression": "donor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"claim_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_codes_user_id_users_id_fk": {
+          "name": "claim_codes_user_id_users_id_fk",
+          "tableFrom": "claim_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "claim_codes_weekly_pool_id_weekly_pools_id_fk": {
+          "name": "claim_codes_weekly_pool_id_weekly_pools_id_fk",
+          "tableFrom": "claim_codes",
+          "tableTo": "weekly_pools",
+          "columnsFrom": [
+            "weekly_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "claim_codes_donor_user_id_users_id_fk": {
+          "name": "claim_codes_donor_user_id_users_id_fk",
+          "tableFrom": "claim_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "donor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "claim_codes_code_unique": {
+          "name": "claim_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "claim_codes_amount_positive": {
+          "name": "claim_codes_amount_positive",
+          "value": "\"claim_codes\".\"amount\" > 0"
+        },
+        "claim_codes_status_valid": {
+          "name": "claim_codes_status_valid",
+          "value": "\"claim_codes\".\"status\" in ('pending', 'active', 'redeemed', 'expired', 'cancelled')"
+        },
+        "claim_codes_expiry_valid": {
+          "name": "claim_codes_expiry_valid",
+          "value": "\"claim_codes\".\"expires_at\" > \"claim_codes\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.donations": {
+      "name": "donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "notify_on_spend": {
+          "name": "notify_on_spend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "donations_user_id_unique": {
+          "name": "donations_user_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "donations_user_id_users_id_fk": {
+          "name": "donations_user_id_users_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "donations_amount_positive": {
+          "name": "donations_amount_positive",
+          "value": "\"donations\".\"amount\" > 0"
+        },
+        "donations_status_valid": {
+          "name": "donations_status_valid",
+          "value": "\"donations\".\"status\" in ('active', 'paused', 'cancelled')"
+        },
+        "donations_date_window_valid": {
+          "name": "donations_date_window_valid",
+          "value": "\"donations\".\"end_date\" is null or \"donations\".\"end_date\" >= \"donations\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.get_credentials": {
+      "name": "get_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_pin": {
+          "name": "encrypted_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "get_credentials_user_id_users_id_fk": {
+          "name": "get_credentials_user_id_users_id_fk",
+          "tableFrom": "get_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "get_credentials_user_id_unique": {
+          "name": "get_credentials_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "claim_code_id": {
+          "name": "claim_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donor_user_id": {
+          "name": "donor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'donor_spend'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expo_ticket_ids": {
+          "name": "expo_ticket_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_deliveries_retry": {
+          "name": "idx_notification_deliveries_retry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_claim_code_id_claim_codes_id_fk": {
+          "name": "notification_deliveries_claim_code_id_claim_codes_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "claim_codes",
+          "columnsFrom": [
+            "claim_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_donor_user_id_users_id_fk": {
+          "name": "notification_deliveries_donor_user_id_users_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "donor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_claim_code_id_unique": {
+          "name": "notification_deliveries_claim_code_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "claim_code_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "notification_deliveries_kind_valid": {
+          "name": "notification_deliveries_kind_valid",
+          "value": "\"notification_deliveries\".\"kind\" = 'donor_spend'"
+        },
+        "notification_deliveries_status_valid": {
+          "name": "notification_deliveries_status_valid",
+          "value": "\"notification_deliveries\".\"status\" in ('pending', 'sending', 'submitted', 'sent', 'failed', 'skipped')"
+        },
+        "notification_deliveries_attempts_nonnegative": {
+          "name": "notification_deliveries_attempts_nonnegative",
+          "value": "\"notification_deliveries\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_push_tokens_user_enabled": {
+          "name": "idx_push_tokens_user_enabled",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_tokens_user_id_users_id_fk": {
+          "name": "push_tokens_user_id_users_id_fk",
+          "tableFrom": "push_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_platform_valid": {
+          "name": "push_tokens_platform_valid",
+          "value": "\"push_tokens\".\"platform\" in ('ios', 'android')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.redemptions": {
+      "name": "redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "claim_code_id": {
+          "name": "claim_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "get_tools_transaction_id": {
+          "name": "get_tools_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "redemptions_claim_code_id_unique": {
+          "name": "redemptions_claim_code_id_unique",
+          "columns": [
+            {
+              "expression": "claim_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "redemptions_claim_code_id_claim_codes_id_fk": {
+          "name": "redemptions_claim_code_id_claim_codes_id_fk",
+          "tableFrom": "redemptions",
+          "tableTo": "claim_codes",
+          "columnsFrom": [
+            "claim_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "redemptions_user_id_users_id_fk": {
+          "name": "redemptions_user_id_users_id_fk",
+          "tableFrom": "redemptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "redemptions_amount_positive": {
+          "name": "redemptions_amount_positive",
+          "value": "\"redemptions\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_allowances": {
+      "name": "user_allowances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_pool_id": {
+          "name": "weekly_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_amount": {
+          "name": "used_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "remaining_amount": {
+          "name": "remaining_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_allowances_user_weekly_pool_unique": {
+          "name": "user_allowances_user_weekly_pool_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weekly_pool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_allowances_user_id_users_id_fk": {
+          "name": "user_allowances_user_id_users_id_fk",
+          "tableFrom": "user_allowances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_allowances_weekly_pool_id_weekly_pools_id_fk": {
+          "name": "user_allowances_weekly_pool_id_weekly_pools_id_fk",
+          "tableFrom": "user_allowances",
+          "tableTo": "weekly_pools",
+          "columnsFrom": [
+            "weekly_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_allowances_amounts_nonnegative": {
+          "name": "user_allowances_amounts_nonnegative",
+          "value": "\"user_allowances\".\"weekly_limit\" >= 0 and \"user_allowances\".\"used_amount\" >= 0 and \"user_allowances\".\"remaining_amount\" >= 0"
+        },
+        "user_allowances_remaining_within_limit": {
+          "name": "user_allowances_remaining_within_limit",
+          "value": "\"user_allowances\".\"remaining_amount\" <= \"user_allowances\".\"weekly_limit\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_pools": {
+      "name": "weekly_pools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_end": {
+          "name": "week_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "allocated_amount": {
+          "name": "allocated_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "remaining_amount": {
+          "name": "remaining_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "weekly_pools_week_start_unique": {
+          "name": "weekly_pools_week_start_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "week_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "weekly_pools_window_valid": {
+          "name": "weekly_pools_window_valid",
+          "value": "\"weekly_pools\".\"week_end\" > \"weekly_pools\".\"week_start\""
+        },
+        "weekly_pools_amounts_nonnegative": {
+          "name": "weekly_pools_amounts_nonnegative",
+          "value": "\"weekly_pools\".\"total_amount\" >= 0 and \"weekly_pools\".\"allocated_amount\" >= 0 and \"weekly_pools\".\"remaining_amount\" >= 0"
+        },
+        "weekly_pools_balances_within_total": {
+          "name": "weekly_pools_balances_within_total",
+          "value": "\"weekly_pools\".\"allocated_amount\" <= \"weekly_pools\".\"total_amount\" and \"weekly_pools\".\"remaining_amount\" <= \"weekly_pools\".\"total_amount\""
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1774481946425,
       "tag": "0005_chief_maria_hill",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1787166396478,
+      "tag": "0006_premium_silver_samurai",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -114,6 +114,55 @@ export const claimCodes = pgTable(
   ]
 );
 
+// Expo push tokens are scoped to a signed-in app user. A user can have more
+// than one active device, while a token can belong to only one user at a time.
+export const pushTokens = pgTable(
+  "push_tokens",
+  {
+    token: text("token").primaryKey(),
+    userId: uuid("user_id").references(() => users.id).notNull(),
+    platform: text("platform").notNull(),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_push_tokens_user_enabled").on(table.userId, table.enabled),
+    check("push_tokens_platform_valid", sql`${table.platform} in ('ios', 'android')`),
+  ]
+);
+
+// A durable outbox prevents duplicate donor notifications when redemption is
+// checked concurrently and preserves the exact title/body that were sent.
+export const notificationDeliveries = pgTable(
+  "notification_deliveries",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    claimCodeId: uuid("claim_code_id").references(() => claimCodes.id).notNull().unique(),
+    donorUserId: uuid("donor_user_id").references(() => users.id).notNull(),
+    kind: text("kind").notNull().default("donor_spend"),
+    status: text("status").notNull().default("pending"),
+    title: text("title"),
+    body: text("body"),
+    attemptCount: integer("attempt_count").notNull().default(0),
+    expoTicketIds: text("expo_ticket_ids"),
+    lastError: text("last_error"),
+    submittedAt: timestamp("submitted_at"),
+    sentAt: timestamp("sent_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_notification_deliveries_retry").on(table.status, table.updatedAt),
+    check("notification_deliveries_kind_valid", sql`${table.kind} = 'donor_spend'`),
+    check(
+      "notification_deliveries_status_valid",
+      sql`${table.status} in ('pending', 'sending', 'submitted', 'sent', 'failed', 'skipped')`
+    ),
+    check("notification_deliveries_attempts_nonnegative", sql`${table.attemptCount} >= 0`),
+  ]
+);
+
 // Redemptions table - tracks code redemption history
 export const redemptions = pgTable(
   "redemptions",
@@ -187,6 +236,14 @@ export const adminConfig = pgTable(
     androidRequiredVersion: text("android_required_version").notNull().default("1.0.0"),
     iosStoreUrl: text("ios_store_url"),
     androidStoreUrl: text("android_store_url"),
+    donorSpendNotificationTitle: text("donor_spend_notification_title")
+      .notNull()
+      .default("Your SlugPoints helped someone"),
+    donorSpendNotificationBody: text("donor_spend_notification_body")
+      .notNull()
+      .default(
+        "Someone just spent {{amount}} of your donated SlugPoints. Thank you for sharing!"
+      ),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,7 +234,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1684,7 +1683,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1799,6 +1797,27 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3091,7 +3110,6 @@
       "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.13.tgz",
       "integrity": "sha512-pV623uwyKjw/L1HVWOpwWOu/ISLH1+c+ESVv30alQMbEaE3cLcwcQ+UnHiAGayMBNMQwK57eckOgH40RBXHfCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/dom-webview": "^55.0.6",
         "anser": "^1.4.9",
@@ -5845,7 +5863,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.3.16.tgz",
       "integrity": "sha512-Wy/6mai2HpA5AEVFk7JFfvv4RUArwuN2UenP/fc3NK7kOyfSlNu1tmb/3JDPpMzPIRbF1MPB8PKAHjVB29qNEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.21.12",
         "escape-string-regexp": "^4.0.0",
@@ -9179,7 +9196,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9501,7 +9517,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -9778,7 +9793,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -11065,7 +11079,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.29.tgz",
       "integrity": "sha512-mCP2YH+a3lN6QWjaW6cBY7YLXvzCoeiVD76d4LJNrNFgvmN9smM2Qmg6+VTwaGhkt+upYx+GsChA+R7i9QyiPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "55.0.35",
@@ -11150,7 +11163,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.17.tgz",
       "integrity": "sha512-t0SNWmXTjXPCHzjNsv1Okjaj8SpXQcUjDPtYDqvofDS+BhAsvlKNmwaaWXvduBjjmmmJWNH8q1/x9IWQ+upg8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/env": "~2.1.3"
       },
@@ -11231,7 +11243,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.8.tgz",
       "integrity": "sha512-WyP75pnKqhLNktYwDn3xKAUNt5rLihRDv8XWGhhz6VEhVqypixpT86NA3uGtiDTlM3gGjhrYCY7o7ypXgCUOZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -11293,7 +11304,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-55.0.17.tgz",
       "integrity": "sha512-rc41rUbFYdJ4IdPxWQiTDtkOlEbtYQkvsCASzW1pqskfRShAd4tYyyAw1BTez3Cq1IgWkK3wcGR+HbFdzZ7ImQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~55.0.17",
         "invariant": "^2.2.4"
@@ -11470,7 +11480,6 @@
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-55.0.12.tgz",
       "integrity": "sha512-yuNHbxobUKCXWn9Z/H+lgYk6heXEFub6q1h8Yo9kCLxgL2afluWZ/YylbtxgHgmFwDVUmi6milQYfL+wwQMlzw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.16.0"
       }
@@ -13919,7 +13928,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.23.tgz",
       "integrity": "sha512-Gvd2WKgvxIXCGotxcI1im/Uf3rS3J3oZGw0g/uskg6AVBZhyE3aAbujkYWzS3xLmEPEtTLfkaVQUKK0KMTSIkA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.23",
         "@swc/helpers": "0.5.15",
@@ -15051,7 +15059,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
       "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -15467,7 +15474,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15508,7 +15514,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15545,7 +15550,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.10.tgz",
       "integrity": "sha512-4gbmtAyfC0F4jU2hl/l/HZbRIfRl0d5RdHNpJLf7sT/0zhYDEhiFcFk7ii2utl7O8BIHRUmGe/anfWP3DNPTZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.83.10",
@@ -15614,7 +15618,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -15625,7 +15628,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.23.0.tgz",
       "integrity": "sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -15652,7 +15654,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -15772,7 +15773,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18813,7 +18813,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,7 @@
         "expo-dev-client": "~55.0.38",
         "expo-linking": "~55.0.17",
         "expo-maps": "~55.0.22",
+        "expo-notifications": "~55.0.26",
         "expo-router": "~55.0.18",
         "expo-status-bar": "~55.0.6",
         "expo-symbols": "~55.0.9",
@@ -9619,6 +9620,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -11108,6 +11115,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.18.tgz",
+      "integrity": "sha512-w4f2b+gJNsspVXgy7Q9kb4P9wtzLHkwsZeiJEaYK+y6uTbpxuPsNQw9WUp7IyMWkxdEZm9TOcgAVKa+1DMhS5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "55.0.19",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-55.0.19.tgz",
@@ -11342,6 +11358,24 @@
         "react-native-worklets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "55.0.26",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-55.0.26.tgz",
+      "integrity": "sha512-hcu1n8/lgoFsf1I4hvNamzDze96SOCl8NIku8SDJ9R2fzn1Q9nndqgS7EUiPU096gQQlM4tfOOwllO8g3r7CsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.16",
+        "abort-controller": "^3.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~55.0.18",
+        "expo-constants": "~55.0.17"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-router": {


### PR DESCRIPTION
## What changed

- adds native Expo push registration and donor notification preferences
- sends configurable donor messages when a claim is redeemed
- persists notification delivery state, Expo tickets, and receipts in a durable outbox
- retries transient failures, disables unregistered device tokens, and adds an authenticated Vercel recovery cron
- adds admin controls for the exact notification title/body
- bumps the iOS app to 1.2.2 (build 45) because Expo Notifications requires a new native binary

## Why

Donors should be notified reliably when their donated SlugPoints are spent, without duplicate sends during normal retries or lost jobs when a request finishes early.

## Validation

- `npm test` - 27/27 passed
- `npm run ci:check` - typechecks and migration consistency passed
- `npm exec -- expo-doctor apps/mobile` - 20/20 passed
- `npm run db:audit` - no data, index, constraint, or notifyOnSpend drift
- `npm run dashboard:build` - compiled successfully; production DB logs the expected missing-column warning until migration 0006 is applied
- native iOS notification foreground/background simulator checks passed during implementation

## Rollout order

1. Apply migration 0006 with `npm run db:push`.
2. Set `CRON_SECRET` in Vercel; optionally set `EXPO_ACCESS_TOKEN` if Expo push access-token security is enabled.
3. Merge/deploy the dashboard.
4. Build and submit iOS 1.2.2 (45) with `npm run mobile:eas:testflight`.
