### PR TITLE
Set iOS build number to 55

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -17,7 +17,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.anonymous.slugswap",
-      "buildNumber": "45",
+      "buildNumber": "55",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }


### PR DESCRIPTION
## What changed

- sets the iOS build number to 55 for SlugSwap 1.2.2

## Why

App Store Connect already contains build 54, so the notification-enabled native release must use the next monotonic build number.

## Validation

- App Store Connect build history verified through build 54
- Expo Doctor passed 20/20 checks
- resolved Expo config reports 1.2.2 (55)
